### PR TITLE
支持 RPC 调用：接受和返回 AVObject

### DIFF
--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -43,14 +43,13 @@ Cloud.use('/__engine/1/ping', function(req, res) {
 });
 
 ['1', '1.1'].forEach(function(apiVersion) {
-  ['', '/__engine', '/__engine/rpc'].forEach(function(urlNamespace) {
-    var route = '/' + apiVersion + '/functions';
-    if (urlNamespace !== '') {
-      route = urlNamespace + '/' + apiVersion + '/functions';
-    }
-
+  ['', '/__engine/functions', '/__engine/rpc'].forEach(function(urlNamespace) {
     if (urlNamespace == '/__engine/rpc') {
-      route = '/__engine/' + apiVersion + '/rpc';
+      var route = '/__engine/' + apiVersion + '/rpc';
+    } else if (urlNamespace == '/__engine/functions') {
+      var route = '/__engine/' + apiVersion + '/functions';
+    } else {
+      var route = '/' + apiVersion + '/functions';
     }
 
     // CORS middleware
@@ -236,11 +235,12 @@ Cloud.use('/__engine/1/ping', function(req, res) {
 
       var meta = {
         remoteAddress: req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress,
-        isRpc: urlNamespace == '/__engine/rpc'
       };
       var split = req.url.split('/');
       if (split.length == 2) { // cloud function
-        call(split[1], req.body, req.AV.user, meta, function(err, data) {
+        call(split[1], req.body, req.AV.user, meta, {
+          isRpc: urlNamespace == '/__engine/rpc'
+        }, function(err, data) {
           cb(err, data);
         });
       } else if (split.length == 3) { // class hook
@@ -313,14 +313,18 @@ Cloud.run = function(name, data, options) {
 
 Cloud.rpc = Cloud.run;
 
-var call = function(funcName, params, user, meta, cb) {
+var call = function(funcName, params, user, meta, options, cb) {
+  if (!options) {
+    options = {};
+  }
+
   if (!Cloud.__code[funcName]) {
     var err = new Error("LeanEngine not found function named '" + funcName +  "' for app '" + AV.applicationId + "' on " + NODE_ENV + ".");
     err.statusCode = 404;
     return cb(err);
   }
   try {
-    if (meta.isRpc) {
+    if (options.isRpc) {
       params = convertRpcParams(params);
     }
 
@@ -330,7 +334,7 @@ var call = function(funcName, params, user, meta, cb) {
       meta: meta
     }, {
       success: function(result) {
-        if (meta.isRpc) {
+        if (options.isRpc) {
           result = convertRpcResult(result);
         }
         return cb(null, result);

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -324,6 +324,8 @@ Cloud.run = function(name, data, options) {
   return promise._thenRunCallbacks(options);
 };
 
+Cloud.rpc = Cloud.run;
+
 var call = function(funcName, params, user, meta, cb) {
   if (!Cloud.__code[funcName]) {
     var err = new Error("LeanEngine not found function named '" + funcName +  "' for app '" + AV.applicationId + "' on " + NODE_ENV + ".");

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -43,14 +43,8 @@ Cloud.use('/__engine/1/ping', function(req, res) {
 });
 
 ['1', '1.1'].forEach(function(apiVersion) {
-  ['', '/__engine/functions', '/__engine/rpc'].forEach(function(urlNamespace) {
-    if (urlNamespace == '/__engine/rpc') {
-      var route = '/__engine/' + apiVersion + '/rpc';
-    } else if (urlNamespace == '/__engine/functions') {
-      var route = '/__engine/' + apiVersion + '/functions';
-    } else {
-      var route = '/' + apiVersion + '/functions';
-    }
+  ['functions', 'call'].forEach(function(urlEndpoint) {
+    var route = '/' + apiVersion + '/' + urlEndpoint;
 
     // CORS middleware
     Cloud.use(route, function(req, res, next) {
@@ -239,7 +233,7 @@ Cloud.use('/__engine/1/ping', function(req, res) {
       var split = req.url.split('/');
       if (split.length == 2) { // cloud function
         call(split[1], req.body, req.AV.user, meta, {
-          isRpc: urlNamespace == '/__engine/rpc'
+          decodeAVObject: urlEndpoint == 'call'
         }, function(err, data) {
           cb(err, data);
         });
@@ -311,8 +305,6 @@ Cloud.run = function(name, data, options) {
   return promise._thenRunCallbacks(options);
 };
 
-Cloud.rpc = Cloud.run;
-
 var call = function(funcName, params, user, meta, options, cb) {
   if (!options) {
     options = {};
@@ -324,8 +316,8 @@ var call = function(funcName, params, user, meta, options, cb) {
     return cb(err);
   }
   try {
-    if (options.isRpc) {
-      params = convertRpcParams(params);
+    if (options.decodeAVObject) {
+      params = decodeParams(params);
     }
 
     Cloud.__code[funcName]({
@@ -334,8 +326,8 @@ var call = function(funcName, params, user, meta, options, cb) {
       meta: meta
     }, {
       success: function(result) {
-        if (options.isRpc) {
-          result = convertRpcResult(result);
+        if (options.decodeAVObject) {
+          result = encodeResult(result);
         }
         return cb(null, result);
       },
@@ -373,7 +365,7 @@ var classHook = function(className, hook, object, user, meta, cb) {
     return cb(err);
   }
 
-  var obj = convertRpcParams(AV._.extend({}, object, {
+  var obj = decodeParams(AV._.extend({}, object, {
     __type: 'Object',
     className: className
   }));
@@ -556,8 +548,8 @@ var signByKey = function(timestamp, key) {
   return crypto.createHash('md5').update("" + timestamp + key).digest("hex");
 };
 
-var convertRpcResult = function(result) {
-  var AVObjectToJSON = function(object) {
+var encodeResult = function(result) {
+  var encodeAVObject = function(object) {
     if (object && object._toFullJSON){
       object = object._toFullJSON([]);
     }
@@ -569,14 +561,14 @@ var convertRpcResult = function(result) {
 
   if (util.isArray(result)) {
     return result.map(function(object) {
-      return AVObjectToJSON(object);
+      return encodeAVObject(object);
     });
   } else {
-    return AVObjectToJSON(result);
+    return encodeAVObject(result);
   }
 };
 
-var convertRpcParams = function(params) {
+var decodeParams = function(params) {
   return AV._decode('', params);
 };
 

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -9,7 +9,8 @@ var connect = require('connect'),
   utils = require('./utils'),
   avosExpressCookieSession = require('./avosExpressCookieSession'),
   avosExpressHttpsRedirect = require('./avosExpressHttpsRedirect'),
-  debug = require('debug')('AV:LeanEngine');
+  debug = require('debug')('AV:LeanEngine'),
+  util = require('util');
 
 if (process.env.LC_API_SERVER) {
   AV.serverURL = process.env.LC_API_SERVER;
@@ -42,10 +43,14 @@ Cloud.use('/__engine/1/ping', function(req, res) {
 });
 
 ['1', '1.1'].forEach(function(apiVersion) {
-  ['', '/__engine'].forEach(function(urlNamespace) {
+  ['', '/__engine', '/__engine/rpc'].forEach(function(urlNamespace) {
     var route = '/' + apiVersion + '/functions';
     if (urlNamespace !== '') {
       route = urlNamespace + '/' + apiVersion + '/functions';
+    }
+
+    if (urlNamespace == '/__engine/rpc') {
+      route = '/__engine/' + apiVersion + '/rpc';
     }
 
     // CORS middleware
@@ -231,6 +236,7 @@ Cloud.use('/__engine/1/ping', function(req, res) {
 
       var meta = {
         remoteAddress: req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress,
+        isRpc: urlNamespace == '/__engine/rpc'
       };
       var split = req.url.split('/');
       if (split.length == 2) { // cloud function
@@ -325,12 +331,19 @@ var call = function(funcName, params, user, meta, cb) {
     return cb(err);
   }
   try {
+    if (meta.isRpc) {
+      params = convertRpcParams(params);
+    }
+
     Cloud.__code[funcName]({
       params: params,
       user: user,
       meta: meta
     }, {
       success: function(result) {
+        if (meta.isRpc) {
+          result = convertRpcResult(result);
+        }
         return cb(null, result);
       },
       error: function(err) {
@@ -547,5 +560,28 @@ var signByKey = function(timestamp, key) {
   return crypto.createHash('md5').update("" + timestamp + key).digest("hex");
 };
 
+var convertRpcResult = function(result) {
+  var AVObjectToJSON = function(object) {
+    if (object && object._toFullJSON){
+      object = object._toFullJSON([]);
+    }
+
+    return AV._.mapObject(object, function(value) {
+      return AV._encode(value, []);
+    });
+  };
+
+  if (util.isArray(result)) {
+    return result.map(function(object) {
+      return AVObjectToJSON(object);
+    });
+  } else {
+    return AVObjectToJSON(result);
+  }
+};
+
+var convertRpcParams = function(params) {
+  return AV._decode('', params);
+};
 
 module.exports = AV;

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -272,19 +272,6 @@ Cloud.use('/__engine/1/ping', function(req, res) {
   });
 });
 
-var createAVObject = function(className) {
-  switch (className) {
-    case '_User':
-      return new AV.User();
-    case '_Role':
-      return new AV.Role();
-    case '_Installation':
-      return new AV.Installation();
-    default:
-      return new AV.Object(className);
-  }
-};
-
 var resp = function(res, data) {
   res.setHeader('Content-Type', 'application/json; charset=UTF-8');
   res.statusCode = 200;
@@ -381,8 +368,11 @@ var classHook = function(className, hook, object, user, meta, cb) {
     err.statusCode = 404;
     return cb(err);
   }
-  var obj = createAVObject(className);
-  obj._finishFetch(object, true);
+
+  var obj = convertRpcParams(AV._.extend({}, object, {
+    __type: 'Object',
+    className: className
+  }));
 
   // for beforeUpdate
   if (object._updatedKeys) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "blanket": "1.1.6",
     "expect.js ": "0.2.0",
     "express": "4.9.7",
-    "mocha": "1.9.0",
+    "mocha": "2.3.3",
     "should": "3.3.2",
     "supertest": "0.14.0"
   },

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -90,6 +90,14 @@ AV.Cloud.define('testAVObjectParams', function(request, response) {
   response.success();
 });
 
+AV.Cloud.define('testBareAVObjectParams', function(request, response) {
+  request.params.should.be.instanceof(AV.Object);
+  request.params.get('name').should.be.equal('avObject');
+  request.params.get('avFile').should.be.instanceof(AV.File);
+  request.params.get('avFile').name().should.be.equal('hello.txt');
+  response.success();
+});
+
 AV.Cloud.define('testUser', function(request, response) {
   assert.equal(request.user.className, '_User');
   assert.equal(request.user.id, '54fd6a03e4b06c41e00b1f40');
@@ -366,6 +374,27 @@ describe('functions', function() {
           className: 'ComplexObject',
           name: 'avObjects'
         }]
+      })
+      .expect(200, function(err, res) {
+        done(err);
+      });
+  });
+
+  // 测试发送单个 AVObject 作为请求参数
+  it('testBareAVObjectParams', function(done) {
+    request(AV.Cloud)
+      .post('/__engine/1.1/rpc/testBareAVObjectParams')
+      .set('X-AVOSCloud-Application-Id', appId)
+      .set('X-AVOSCloud-Application-Key', appKey)
+      .send({
+        __type: 'Object',
+        className: 'ComplexObject',
+        name: 'avObject',
+        avFile: {
+          __type: 'File',
+          url: 'http://ac-1qdney6b.qiniudn.com/3zLG4o0d27MsCQ0qHGRg4JUKbaXU2fiE35HdhC8j.txt',
+          name: 'hello.txt'
+        },
       })
       .expect(200, function(err, res) {
         done(err);

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -13,6 +13,7 @@ var masterKey = config.masterKey;
 AV.initialize(appId, appKey, masterKey);
 
 var TestObject = AV.Object.extend('TestObject');
+var ComplexObject = AV.Object.extend('ComplexObject');
 
 AV.Cloud.define('foo', function(request, response) {
   assert.ok(request.meta.remoteAddress);
@@ -31,27 +32,26 @@ AV.Cloud.define('choice', function(req, res) {
   }
 });
 
-// TODO 该特性待后续 rpc 方法时再支持
-//AV.Cloud.define('complexObject', function(request, response) {
-//  var query = new AV.Query(ComplexObject);
-//  query.include('fileColumn');
-//  query.ascending('createdAt');
-//  query.find({
-//    success: function(results) {
-//      response.success({
-//        foo: 'bar',
-//        i: 123,
-//        obj: {
-//          a: 'b',
-//          as: [1,2,3],
-//        },
-//        t: new Date('2015-05-14T09:21:18.273Z'),
-//        avObject: results[0],
-//        avObjects: results,
-//      });
-//    }
-//  })
-//})
+AV.Cloud.define('complexObject', function(request, response) {
+  var query = new AV.Query(ComplexObject);
+  query.include('fileColumn');
+  query.ascending('createdAt');
+  query.find({
+    success: function(results) {
+      response.success({
+        foo: 'bar',
+        i: 123,
+        obj: {
+          a: 'b',
+          as: [1, 2, 3],
+        },
+        t: new Date('2015-05-14T09:21:18.273Z'),
+        avObject: results[0],
+        avObjects: results,
+      });
+    }
+  })
+})
 
 AV.Cloud.define('testUser', function(request, response) {
   assert.equal(request.user.className, '_User');
@@ -218,27 +218,28 @@ describe('functions', function() {
       .expect({result: {action: "hello", name: "张三"}}, done);
   });
 
-  // TODO 该特性待后续 rpc 方法时再支持
-  //it('return_complexObject', function(done) {
-  //  request(AV.Cloud)
-  //    .post('/1/functions/complexObject')
-  //    .set('X-AVOSCloud-Application-Id', appId)
-  //    .set('X-AVOSCloud-Application-Key', appKey)
-  //    .expect(200, function(err, res) {
-  //      var result = res.body.result;
-  //      result.foo.should.equal('bar');
-  //      result.t.should.eql({ __type: 'Date', iso: '2015-05-14T09:21:18.273Z' });
-  //      result.avObject.numberColumn.should.equal(1.23);
-  //      result.avObject.__type.should.equal('Object');
-  //      result.avObject.className.should.equal('ComplexObject');
-  //      result.avObject.fileColumn.should.eql({ __type: 'File',
-  //                                             id: '55543fc2e4b0846760bd92f3',
-  //                                             name: 'ttt.jpg',
-  //                                             url: 'http://ac-4h2h4okw.clouddn.com/4qSbLMO866Tf4YtT9QEwJwysTlHGC9sMl7bpTwhQ.jpg' });
-  //      done();
-  //    })
-  //});
-  //
+  it('return_complexObject', function(done) {
+   request(AV.Cloud)
+     .post('/__engine/1.1/rpc/complexObject')
+     .set('X-AVOSCloud-Application-Id', appId)
+     .set('X-AVOSCloud-Application-Key', appKey)
+     .expect(200, function(err, res) {
+       var result = res.body.result;
+       result.foo.should.equal('bar');
+       result.t.should.eql({ __type: 'Date', iso: '2015-05-14T09:21:18.273Z' });
+       result.avObject.numberColumn.should.equal(1.23);
+       result.avObject.__type.should.equal('Object');
+       result.avObject.className.should.equal('ComplexObject');
+       result.avObject.fileColumn.should.eql({
+          __type: 'File',
+          id: '55543fc2e4b0846760bd92f3',
+          name: 'ttt.jpg',
+          url: 'http://ac-4h2h4okw.clouddn.com/4qSbLMO866Tf4YtT9QEwJwysTlHGC9sMl7bpTwhQ.jpg'
+       });
+       done();
+     })
+  });
+
   //it('return_AVObjects', function(done) {
   //  request(AV.Cloud)
   //    .post('/1/functions/complexObjects')

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -249,16 +249,6 @@ describe('functions', function() {
       .expect({result: "bar"}, done);
   });
 
-  // 测试 `/__engine` URL namespace  的有效性
-  it('urlNamespace', function(done) {
-    request(AV.Cloud)
-      .post('/__engine/1.1/functions/foo')
-      .set('X-AVOSCloud-Application-Id', appId)
-      .set('X-AVOSCloud-Application-Key', appKey)
-      .expect(200)
-      .expect({result: "bar"}, done);
-  });
-
   // 测试参数的正确解析
   it('hello', function(done) {
     request(AV.Cloud)
@@ -273,7 +263,7 @@ describe('functions', function() {
   // 测试返回包含 AVObject 的复杂对象
   it('return_complexObject', function(done) {
     request(AV.Cloud)
-      .post('/__engine/1.1/rpc/complexObject')
+      .post('/1.1/call/complexObject')
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .expect(200, function(err, res) {
@@ -330,7 +320,7 @@ describe('functions', function() {
   // 返回单个 AVObject
   it('return_bareAVObject', function(done) {
     request(AV.Cloud)
-      .post('/__engine/1.1/rpc/bareAVObject')
+      .post('/1.1/call/bareAVObject')
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .expect(200, function(err, res) {
@@ -344,7 +334,7 @@ describe('functions', function() {
   // 返回 AVObject 数组
   it('return_AVObjectsArray', function(done) {
     request(AV.Cloud)
-      .post('/__engine/1.1/rpc/AVObjects')
+      .post('/1.1/call/AVObjects')
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .expect(200, function(err, res) {
@@ -359,7 +349,7 @@ describe('functions', function() {
   // 测试发送包含 AVObject 的请求
   it('testAVObjectParams', function(done) {
     request(AV.Cloud)
-      .post('/__engine/1.1/rpc/testAVObjectParams')
+      .post('/1.1/call/testAVObjectParams')
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .send({
@@ -392,7 +382,7 @@ describe('functions', function() {
   // 测试发送单个 AVObject 作为请求参数
   it('testBareAVObjectParams', function(done) {
     request(AV.Cloud)
-      .post('/__engine/1.1/rpc/testBareAVObjectParams')
+      .post('/1.1/call/testBareAVObjectParams')
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .send({
@@ -424,7 +414,7 @@ describe('functions', function() {
     };
 
     request(AV.Cloud)
-      .post('/__engine/1.1/rpc/testAVObjectsArrayParams')
+      .post('/1.1/call/testAVObjectsArrayParams')
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .send([object, object])
@@ -445,7 +435,7 @@ describe('functions', function() {
 
   it('testRun_AVObjects', function(done) {
    request(AV.Cloud)
-     .post('/__engine/1.1/rpc/testRunWithAVObject')
+     .post('/1.1/call/testRunWithAVObject')
      .set('X-AVOSCloud-Application-Id', appId)
      .set('X-AVOSCloud-Application-Key', appKey)
      .expect(200, function(err, res) {

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -114,14 +114,13 @@ AV.Cloud.define('testRunWithUser', function(request, response) {
   });
 });
 
-// TODO 该特性待后续 rpc 方法时再支持
-//AV.Cloud.define('testRunWithAVObject', function(request, response) {
-//  AV.Cloud.run('complexObjects', {}, {
-//    success: function(datas) {
-//      response.success(datas);
-//    }
-//  });
-//})
+AV.Cloud.define('testRunWithAVObject', function(request, response) {
+ AV.Cloud.run('complexObject', {}, {
+   success: function(datas) {
+     response.success(datas);
+   }
+ });
+})
 
 AV.Cloud.define('readDir', function(request, response) {
   fs.readdir('.', function(err, dir) {
@@ -240,17 +239,17 @@ describe('functions', function() {
      })
   });
 
-  //it('return_AVObjects', function(done) {
-  //  request(AV.Cloud)
-  //    .post('/1/functions/complexObjects')
-  //    .set('X-AVOSCloud-Application-Id', appId)
-  //    .set('X-AVOSCloud-Application-Key', appKey)
-  //    .expect(200, function(err, res) {
-  //      res.body.result[0].__type.should.equal('Object');
-  //      res.body.result[0].className.should.equal('ComplexObject');
-  //      done();
-  //    })
-  //});
+  it('return_AVObjects', function(done) {
+   request(AV.Cloud)
+     .post('/__engine/1.1/rpc/complexObject')
+     .set('X-AVOSCloud-Application-Id', appId)
+     .set('X-AVOSCloud-Application-Key', appKey)
+     .expect(200, function(err, res) {
+       res.body.result.avObjects[0].__type.should.equal('Object');
+       res.body.result.avObjects[0].className.should.equal('ComplexObject');
+       done();
+     })
+  });
 
   // 测试 run 方法的有效性
   it('testRun', function(done) {
@@ -262,18 +261,17 @@ describe('functions', function() {
       .expect({}, done);
   });
 
-  // TODO 该特性待后续 rpc 方法时再支持
-  //it('testRun_AVObjects', function(done) {
-  //  request(AV.Cloud)
-  //    .post('/1/functions/testRunWithAVObject')
-  //    .set('X-AVOSCloud-Application-Id', appId)
-  //    .set('X-AVOSCloud-Application-Key', appKey)
-  //    .expect(200, function(err, res) {
-  //      res.body.result[0].__type.should.equal('Object');
-  //      res.body.result[0].className.should.equal('ComplexObject');
-  //      done();
-  //    })
-  //});
+  it('testRun_AVObjects', function(done) {
+   request(AV.Cloud)
+     .post('/__engine/1.1/rpc/testRunWithAVObject')
+     .set('X-AVOSCloud-Application-Id', appId)
+     .set('X-AVOSCloud-Application-Key', appKey)
+     .expect(200, function(err, res) {
+       res.body.result.avObjects[0].__type.should.equal('Object');
+       res.body.result.avObjects[0].className.should.equal('ComplexObject');
+       done();
+     })
+  });
 
   it('testRun_text_plain', function(done) {
     request(AV.Cloud)

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -98,6 +98,15 @@ AV.Cloud.define('testBareAVObjectParams', function(request, response) {
   response.success();
 });
 
+AV.Cloud.define('testAVObjectsArrayParams', function(request, response) {
+  request.params.forEach(function(object) {
+    object.get('name').should.be.equal('avObject');
+    object.get('avFile').should.be.instanceof(AV.File);
+    object.get('avFile').name().should.be.equal('hello.txt');
+  });
+  response.success();
+});
+
 AV.Cloud.define('testUser', function(request, response) {
   assert.equal(request.user.className, '_User');
   assert.equal(request.user.id, '54fd6a03e4b06c41e00b1f40');
@@ -396,6 +405,29 @@ describe('functions', function() {
           name: 'hello.txt'
         },
       })
+      .expect(200, function(err, res) {
+        done(err);
+      });
+  });
+
+  // 测试发送 AVObject 数组作为请求参数
+  it('testAVObjectsArrayParams', function(done) {
+    var object = {
+      __type: 'Object',
+      className: 'ComplexObject',
+      name: 'avObject',
+      avFile: {
+        __type: 'File',
+        url: 'http://ac-1qdney6b.qiniudn.com/3zLG4o0d27MsCQ0qHGRg4JUKbaXU2fiE35HdhC8j.txt',
+        name: 'hello.txt'
+      }
+    };
+
+    request(AV.Cloud)
+      .post('/__engine/1.1/rpc/testAVObjectsArrayParams')
+      .set('X-AVOSCloud-Application-Id', appId)
+      .set('X-AVOSCloud-Application-Key', appKey)
+      .send([object, object])
       .expect(200, function(err, res) {
         done(err);
       });

--- a/test/hook_test.js
+++ b/test/hook_test.js
@@ -53,6 +53,11 @@ AV.Cloud.beforeSave("ErrorObject", function(request, response) {
   response.success();
 });
 
+AV.Cloud.beforeSave('ContainsFile', function(request, response) {
+  request.object.get('file').url().should.be.equal('http://ac-4h2h4okw.clouddn.com/4qSbLMO866Tf4YtT9QEwJwysTlHGC9sMl7bpTwhQ.jpg')
+  response.success();
+});
+
 AV.Cloud.afterSave("TestReview", function(request) {
   assert.equal(request.object.className, 'TestReview');
   assert.equal(request.object.id, '5403e36be4b0b77b5746b292');
@@ -116,6 +121,24 @@ describe('hook', function() {
         "stars": 1,
         "comment": "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567..."
       }, done);
+  });
+
+  it('beforeSave_ContainsFile', function(done) {
+    request(AV.Cloud)
+      .post('/1/functions/ContainsFile/beforeSave')
+      .set('X-AVOSCloud-Application-Id', appId)
+      .set('X-AVOSCloud-Application-Key', appKey)
+      .set('Content-Type', 'application/json')
+      .send({
+          object: {
+            file: {
+              __type: 'File',
+              id: '55543fc2e4b0846760bd92f3',
+              url: 'http://ac-4h2h4okw.clouddn.com/4qSbLMO866Tf4YtT9QEwJwysTlHGC9sMl7bpTwhQ.jpg'
+            }
+          }
+      })
+      .expect(200, done)
   });
 
   it('beforeSave_error', function(done) {

--- a/test/hook_test.js
+++ b/test/hook_test.js
@@ -176,10 +176,11 @@ describe('hook', function() {
         }
       })
       .expect(500, function(err, res) {
-        res.body.should.eql({ code: 1, error: 'undefined is not a function' });
+        res.body.code.should.be.equal(1);
+        res.body.error.should.be.match(/(undefined|a\.noThisMethod) is not a function/);
         console.warn = ori;
         warnLogs.length.should.equal(1);
-        warnLogs[0][0].split('\n')[0].should.equal("Execute \'__before_save_for_ErrorObject\' failed with error: TypeError: undefined is not a function");
+        warnLogs[0][0].split('\n')[0].should.match(/Execute '__before_save_for_ErrorObject' failed with error: TypeError: (undefined|a\.noThisMethod) is not a function/);
         done();
       });
   });


### PR DESCRIPTION
添加了 `/1.1/call/:funcName` 这个路由，它会对云代码接受的参数和返回的结果进行处理。

Relation 似乎不需要去支持，Relation 实际上是使用 $relatedTo 操作符的查询，数据会在单独的回调中返回，并不会反映在对象本身上。
- [x] 让 Hook 支持包含 File 的对象 #23 。
- [ ] 还需要在 javascript-sdk 上添加 AV.Cloud.call 方法。

目前 Travis-CI 的失败应该是网络问题，我这里是可以成功运行测试的。
