### PR TITLE
支持 beforeUpdate

### DIFF
--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -368,6 +368,12 @@ var classHook = function(className, hook, object, user, meta, cb) {
   }
   var obj = createAVObject(className);
   obj._finishFetch(object, true);
+
+  // for beforeUpdate
+  if (object._updatedKeys) {
+    obj._updatedKeys = object._updatedKeys;
+  }
+
   setHookMark(obj);
   try {
     if (hook.indexOf('__after_') === 0) {
@@ -449,6 +455,7 @@ Cloud.define = function(name, func) {
 
 var hookNameMapping = {
   beforeSave: '__before_save_for_',
+  beforeUpdate: '__before_update_for_',
   afterSave: '__after_save_for_',
   afterUpdate: '__after_update_for_',
   beforeDelete: '__before_delete_for_',
@@ -466,6 +473,10 @@ Cloud.beforeSave = function(nameOrClass, func) {
 
 Cloud.afterSave = function(nameOrClass, func) {
   _define(className(nameOrClass), '__after_save_for_', func);
+};
+
+Cloud.beforeUpdate = function(nameOrClass, func) {
+  _define(className(nameOrClass), '__before_update_for_', func);
 };
 
 Cloud.afterUpdate = function(nameOrClass, func) {

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -371,7 +371,7 @@ var classHook = function(className, hook, object, user, meta, cb) {
 
   // for beforeUpdate
   if (object._updatedKeys) {
-    obj._updatedKeys = object._updatedKeys;
+    obj.updatedKeys = object._updatedKeys;
   }
 
   setHookMark(obj);

--- a/test/hook_test.js
+++ b/test/hook_test.js
@@ -35,6 +35,12 @@ AV.Cloud.beforeSave("TestReview", function(request, response){
   }
 });
 
+AV.Cloud.beforeUpdate("TestReview", function(request, response) {
+  request.object.get('stars').should.be.equal(1);
+  request.object._updatedKeys.should.be.eql(['stars']);
+  response.success();
+});
+
 AV.Cloud.beforeSave("ErrorObject", function(request, response) {
   var a = {};
   a.noThisMethod();
@@ -184,6 +190,22 @@ describe('hook', function() {
       })
       .expect(404)
       .expect({ code: 1, error: "LeanEngine not found hook '__before_save_for_NoThisObject' for app '" + appId + "' on development." }, done);
+  });
+
+  it('beforeUpdate', function(done) {
+    request(AV.Cloud)
+      .post('/1/functions/TestReview/beforeUpdate')
+      .set('X-AVOSCloud-Application-Id', appId)
+      .set('X-AVOSCloud-Application-Key', appKey)
+      .set('Content-Type', 'application/json')
+      .send({
+        "object": {
+          "_updatedKeys": ['stars'],
+          "comment": "123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890",
+          "stars": 1
+        }
+      })
+      .expect(200, done);
   });
 
   it('afterSave', function(done) {


### PR DESCRIPTION
在 classHook（371 行）加了一个针对 beforeUpdate 的处理，是希望让 _updatedKeys 可以通过 `object.updatedKeys` 而不是 `object.get('_updatedKeys')` 来访问，这样看起来才像一个特殊的字段，而不是对象的属性。

https://github.com/leancloud/leanengine-node-sdk/issues/25
