### PR TITLE
路由统计、云储存 API 调用统计

### DIFF
--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -42,6 +42,10 @@ Cloud.use('/__engine/1/ping', function(req, res) {
   }));
 });
 
+Cloud.use(statusLogger({
+  AV: AV
+}));
+
 ['1', '1.1'].forEach(function(apiVersion) {
   ['functions', 'call'].forEach(function(urlEndpoint) {
     var route = '/' + apiVersion + '/' + urlEndpoint;

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -42,10 +42,6 @@ Cloud.use('/__engine/1/ping', function(req, res) {
   }));
 });
 
-Cloud.use(statusLogger({
-  AV: AV
-}));
-
 ['1', '1.1'].forEach(function(apiVersion) {
   ['functions', 'call'].forEach(function(urlEndpoint) {
     var route = '/' + apiVersion + '/' + urlEndpoint;

--- a/lib/status-logger/README.md
+++ b/lib/status-logger/README.md
@@ -11,7 +11,7 @@
 
 等它收集一段时间数据，就可以打开你的站点下的 `/__lcStatusLogger` 查看统计图表了，basicAuth 的账号是 appId，密码是 masterKey.
 
-数据会储存在你的应用云储存中的 `LeanEngineReponseLog5Min` 和 `LeanEngineCloudAPI5Min` 这两个 Class 中，你的程序（每个实例）每五分钟会分别上传一条记录，每天会上传大概五百条。
+数据会储存在你的应用云储存中的 `LeanEngineReponseLog5Min` 和 `LeanEngineCloudAPI5Min` 这两个 Class 中，你的程序（每个实例）每五分钟会分别上传一条记录到这两张表，这意味着每个 LeanEngine 实例每个月会因为统计调用情况而消耗 17k 次 api 调用。
 
 **定义自己的 URL 分组或忽略规则**：
 
@@ -20,8 +20,8 @@
     app.use(statusLogger({
       AV: AV,
       rules: [
-        {match: /^GET \/(js|css).+/, rewrite: 'GET /$1'} // 将例如 /js/jquery.js 的 URL 重写为 /js
-        {match: /^GET \/public/, ignore: true}           // 忽略 GET /public 开头的 URL
+        {match: /^GET \/(js|css).+/, rewrite: 'GET /$1'}, // 将例如 /js/jquery.js 的 URL 重写为 /js
+        {match: /^GET \/public/, ignore: true}            // 忽略 GET /public 开头的 URL
       ]
     }));
 

--- a/lib/status-logger/README.md
+++ b/lib/status-logger/README.md
@@ -1,0 +1,30 @@
+## LeanEngine 路由、云储存调用统计
+
+这个中间件会统计 express 程序被访问的各路由的响应代码、响应时间，以及程序所调用的 LeanCloud API 的名称、响应结果（成功或失败）、响应时间。
+
+**在你的 express 程序中添加**：
+
+    var statusLogger = require('leanengine/lib/status-logger');
+    var AV = require('leanengine');
+    var app = express();
+    app.use(statusLogger({AV: AV}));
+
+等它收集一段时间数据，就可以打开你的站点下的 `/__lcStatusLogger` 查看统计图表了，basicAuth 的账号是 appId，密码是 masterKey.
+
+数据会储存在你的应用云储存中的 `LeanEngineReponseLog5Min` 和 `LeanEngineCloudAPI5Min` 这两个 Class 中，你的程序（每个实例）每五分钟会分别上传一条记录，每天会上传大概五百条。
+
+**定义自己的 URL 分组或忽略规则**：
+
+你可以给 statusLogger 传一个 rules 参数，定义一些处理 URL 的规则：
+
+    app.use(statusLogger({
+      AV: AV,
+      rules: [
+        {match: /^GET \/(js|css).+/, rewrite: 'GET /$1'} // 将例如 /js/jquery.js 的 URL 重写为 /js
+        {match: /^GET \/public/, ignore: true}           // 忽略 GET /public 开头的 URL
+      ]
+    }));
+
+**statusLogger 的更多选项**：
+
+* specialStatusCodes, 数字数组，为了记录合适大小的数据，默认只会单独记录几个常见的 statusCode, 你可以覆盖默认的值。

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -24,16 +24,9 @@ module.exports = exports = function(options) {
   var specialStatusCodes = options.specialStatusCodes || [200, 201, 302, 304, 400, 404, 500, 502];
   var rewriteRules = options.rules || [];
 
-  var nameOfStatusCode = function(code) {
-    if (_.contains(specialStatusCodes, code))
-      return 'status' + code;
-    else
-      return null;
-  };
-
   var collector = createCollector(_.extend({
     className: 'LeanEngineReponseLog5Min',
-    counterFields: specialStatusCodes.map(nameOfStatusCode)
+    counterFields: specialStatusCodes
   }, options));
 
   return function statusLogger(req, res, next) {
@@ -81,7 +74,9 @@ module.exports = exports = function(options) {
       };
 
       record[typeOfStatusCode(res.statusCode)] = 1;
-      record[nameOfStatusCode(res.statusCode)] = 1;
+
+      if (_.contains(specialStatusCodes, res.statusCode))
+        record[res.statusCode] = 1;
 
       debug('router: %s %s %sms', urlPattern, res.statusCode, responseTime);
       collector.putRecord(record);
@@ -190,7 +185,12 @@ function createCollector(options) {
     };
 
     counterFields.forEach(function(field) {
-      log[field] = _.reduce(log.urls, function(memory, stat) {
+      var fieldName = field;
+
+      if (!isNaN(parseInt(field)))
+        fieldName = 'status' + field;
+
+      log[fieldName] = _.reduce(log.urls, function(memory, stat) {
         return memory + stat[field];
       }, 0);
     });

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -1,13 +1,21 @@
+'use strict';
+
 var onFinished = require('on-finished');
 var onHeaders = require('on-headers');
+var EventEmitter = require('events');
 var _;
 
 module.exports = function(options) {
   _ = options.AV._;
 
   var collector = createCollector({
-    AV: options.AV
+    AV: options.AV,
+    commitCycle: 60000
   });
+
+  var realtimeJSON = function(req, res) {
+    res.json(collector.recentRecords());
+  };
 
   return function statusLogger(req, res, next) {
     req._lc_startedAt = new Date();
@@ -26,84 +34,89 @@ module.exports = function(options) {
 
       collector.putRecord({
         url: req.originalUrl,
-        endedAt: new Date(),
         statusCode: res.statusCode,
         responseTime: responseTime
       });
     });
 
-    next();
+    if (req.path == '/_lc_realtimeJSON')
+      realtimeJSON(req, res);
+    else
+      next();
   };
 };
 
 function createCollector(options) {
-  var commitCycle = options.commitCycle || 60 * 1000;
+  var commitCycle = options.commitCycle || 300000;
+  var realtimeCycle = options.realtimeCycle || 5000;
 
   var ReponseLog = options.AV.Object.extend('LeanEngineReponseLog');
-  var records = [];
-  var lastCommitTime = new Date();
+  var bucket = {};
+  var realtimeBucket = {};
+  var events = new EventEmitter();
 
   var commitToServer = function() {
-    var groupedRecords = _.groupBy(records, function(record) {
-      return record.url;
-    });
-
-    records = [];
-    lastCommitTime = new Date();
-
-    _.each(groupedRecords, function(records, urlPattern) {
+    _.each(bucket, function(stat) {
       var log = new ReponseLog();
 
-      var fromTime = null;
-      var toTime = null;
-      var responseTimes = {};
-      var statusCodes = {};
+      var requests = stat.success + stat.clientError + stat.serverError + stat.other;
+      stat.avgResponseTime = stat.totalResponseTime / requests;
+      delete stat.totalResponseTime;
 
-      records.forEach(function (record) {
-        if (!fromTime || record.endedAt < fromTime)
-          fromTime = record.endedAt;
-        if (!toTime || record.endedAt > toTime)
-          toTime = record.endedAt;
-
-        if (statusCodes[record.statusCode])
-          statusCodes[record.statusCode]++;
-        else
-          statusCodes[record.statusCode] = 1;
-
-        if (responseTimes[record.responseTime])
-          responseTimes[record.responseTime]++;
-        else
-          responseTimes[record.responseTime] = 1;
-      });
-
-      log.save({
-        from: fromTime,
-        to: toTime,
-        urlPattern: urlPattern,
-        responseTimes: responseTimes,
-        statusCodes: statusCodes
-      }, {
-        success: function() {
-          console.log('Save success', {
-            urlPattern: urlPattern,
-            statusCodes: statusCodes
-          });
+      log.save(stat, {
+        success: function(log) {
+          console.log('Save success', log.attributes);
         },
         error: function(log ,err) {
           console.error(err.stack);
         }
       });
     });
+
+    bucket = {};
   };
 
   setInterval(function() {
-    if (Date.now() - lastCommitTime.getTime() > commitCycle)
-      commitToServer();
-  });
+    commitToServer();
+  }, commitCycle);
+
+  setInterval(function() {
+    events.emit('realtime', realtimeBucket);
+    realtimeBucket = {};
+  }, realtimeCycle);
 
   return {
+    on: events.on.bind(events),
     putRecord: function(record) {
-      records.push(record);
+      var stat = bucket[record.url];
+
+      if (!stat) {
+        stat = bucket[record.url] = {
+          urlPattern: record.url,
+          totalResponseTime: 0,
+          success: 0,
+          clientError: 0,
+          serverError: 0,
+          other: 0
+        };
+      }
+
+      stat[typeOfStatusCode(record.statusCode)]++;
+      stat.totalResponseTime += record.responseTime;
+    },
+    recentRecords: function() {
+      return bucket;
     }
-  }
+  };
+}
+
+function typeOfStatusCode(code) {
+  if (code >= 200 && code < 400)
+    return 'success';
+  else if (code >= 400 && code < 500)
+    return 'clientError';
+  else if (code >= 500)
+    return 'serverError';
+  else
+    return 'other';
 }

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -4,17 +4,16 @@ var onFinished = require('on-finished');
 var onHeaders = require('on-headers');
 var EventEmitter = require('events');
 var pathToRegexp = require('path-to-regexp');
+var debug = require('debug')('AV:statusLogger');
 var _ = require('underscore');
 
+/**
+ * @param options.AV
+ */
 module.exports = function(options) {
   var collector = createCollector({
-    AV: options.AV,
-    commitCycle: 60000
+    AV: options.AV
   });
-
-  var realtimeJSON = function(req, res) {
-    res.json(collector.recentStatistics());
-  };
 
   return function statusLogger(req, res, next) {
     req._lc_startedAt = new Date();
@@ -33,6 +32,8 @@ module.exports = function(options) {
         responseTime = res._lc_startedAt.getTime() - req._lc_startedAt.getTime();
 
       if (req.route) {
+        // 如果这个请求属于一个路由，则用路由路径替换掉 URL 中匹配的部分
+
         var regexp = pathToRegexp(req.route.path).toString().replace(/^\/\^/, '').replace(/\/i$/, '');
         var matched = urlPattern.match(new RegExp(regexp, 'i'));
 
@@ -48,13 +49,20 @@ module.exports = function(options) {
       });
     });
 
-    if (req.path == '/_lc_realtimeJSON')
-      realtimeJSON(req, res);
+    if (req.path == '/_lc_recent.json')
+      res.json(collector.recentStatistics());
+    else if (req.path == '/_lc_realtime.json')
+      res.json(collector.realtimeStatistics());
     else
       next();
   };
 };
 
+/**
+ * @param options.AV
+ * @param options.commitCycle
+ * @param options.realtimeCycle
+ */
 function createCollector(options) {
   var commitCycle = options.commitCycle || 300000;
   var realtimeCycle = options.realtimeCycle || 5000;
@@ -65,6 +73,8 @@ function createCollector(options) {
   var events = new EventEmitter();
 
   var commitToServer = function() {
+    debug('commitToServer');
+
     _.each(bucket, function(stat) {
       var log = new ReponseLog();
 
@@ -108,18 +118,26 @@ function createCollector(options) {
   }, commitCycle);
 
   setInterval(function() {
+    debug('emit realtime');
     events.emit('realtime', realtimeBucket);
     realtimeBucket = {};
   }, realtimeCycle);
 
   return {
     on: events.on.bind(events),
+
     putRecord: function(record) {
+      debug('putRecord: %s %s %sms', record.urlPattern, record.statusCode, record.responseTime);
       putToBucket(bucket, record);
       putToBucket(realtimeBucket, record);
     },
+
     recentStatistics: function() {
       return bucket;
+    },
+
+    realtimeStatistics: function() {
+      return realtimeBucket;
     }
   };
 }

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -8,12 +8,11 @@ var debug = require('debug')('AV:statusLogger');
 var _ = require('underscore');
 var os = require('os');
 
-var instanceId = os.hostname() + ' ' + process.env.LC_APP_PORT;
+var instanceId = os.hostname() + ':' + process.env.LC_APP_PORT;
 
 /**
  * @param {AV} options.AV
  * @param {Number[]=} options.specialStatusCodes
- * @param {String=} options.className
  * @param {Number=300000} options.commitCycle
  * @param {Number=5000} options.realtimeCycle
  * @param {Object[]=} options.rules
@@ -24,12 +23,14 @@ module.exports = exports = function(options) {
   var specialStatusCodes = options.specialStatusCodes || [200, 201, 302, 304, 400, 404, 500, 502];
   var rewriteRules = options.rules || [];
 
-  var collector = createCollector(_.extend({
+  var cloudCollector = collectCloudAPICall(options);
+
+  var routerCollector = createCollector(_.extend({
     className: 'LeanEngineReponseLog5Min',
     counterFields: specialStatusCodes
   }, options));
 
-  return function statusLogger(req, res, next) {
+  var statusLogger = function(req, res, next) {
     req._lc_startedAt = new Date();
 
     onHeaders(res, function() {
@@ -57,6 +58,9 @@ module.exports = exports = function(options) {
 
       urlPattern = req.method.toUpperCase() + ' ' + urlPattern;
 
+      if (urlPattern.match(/__lcStatusLogger/))
+        return;
+
       if (rewriteRules.some(function(rule) {
         if (urlPattern.match(rule.match)) {
           if (rule.ignore)
@@ -65,7 +69,7 @@ module.exports = exports = function(options) {
           urlPattern = urlPattern.replace(rule.match, rule.rewrite);
         }
       })) {
-        return; // some rule return ingore.
+        return;
       }
 
       var record = {
@@ -79,25 +83,25 @@ module.exports = exports = function(options) {
         record[res.statusCode] = 1;
 
       debug('router: %s %s %sms', urlPattern, res.statusCode, responseTime);
-      collector.putRecord(record);
+      routerCollector.putRecord(record);
     });
 
-    if (req.path == '/_lc_recent.json')
-      res.json(collector.recentStatistics());
-    else if (req.path == '/_lc_realtime.json')
-      res.json(collector.realtimeStatistics());
-    else
-      next();
+    next();
   };
+
+  return [statusLogger, require('./server')({
+    AV: options.AV,
+    routerCollector: routerCollector,
+    cloudCollector: cloudCollector
+  })];
 };
 
 /**
  * @param options.AV
- * @param {String=} options.className
  * @param {Number=300000} options.commitCycle
  * @param {Number=5000} options.realtimeCycle
  */
-exports.collectCloudAPICall = function(options) {
+function collectCloudAPICall(options) {
   var AV = options.AV;
   var originalRequest = AV._request;
 
@@ -127,7 +131,7 @@ exports.collectCloudAPICall = function(options) {
     };
 
     promise.then(function(result, statusCode) {
-      if (record.urlPattern.match(/POST classes\/LeanEngine(ReponseLog|CloudAPI)/))
+      if (record.urlPattern.match(/classes\/LeanEngine(ReponseLog|CloudAPI)/))
         return;
 
       record.responseTime = Date.now() - startedAt.getTime();
@@ -148,7 +152,9 @@ exports.collectCloudAPICall = function(options) {
 
     return promise;
   };
-};
+
+  return collector;
+}
 
 /**
  * @param {AV} options.AV
@@ -158,11 +164,12 @@ exports.collectCloudAPICall = function(options) {
  * @param {String[]} options.counterFields
  */
 function createCollector(options) {
+  var AV = options.AV;
   var commitCycle = options.commitCycle || 300000;
   var realtimeCycle = options.realtimeCycle || 5000;
   var counterFields = _.union(['responseTime', 'success', 'clientError', 'serverError'], options.counterFields);
 
-  var Storage = options.AV.Object.extend(options.className);
+  var Storage = AV.Object.extend(options.className);
   var bucket = {};
   var realtimeBucket = {};
   var events = new EventEmitter();
@@ -243,6 +250,12 @@ function createCollector(options) {
     putRecord: function(record) {
       putToBucket(bucket, record);
       putToBucket(realtimeBucket, record);
+    },
+
+    getLastDayStatistics: function(options) {
+      var query = new AV.Query(Storage);
+      query.greaterThan('createdAt', new Date(Date.now() - 24 * 3600 * 1000));
+      return query.limit(1000).find(options);
     },
 
     recentStatistics: function() {

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -20,7 +20,7 @@ var instanceId = os.hostname() + ':' + process.env.LC_APP_PORT;
  *          {match: /^GET \/(js|css).+/, rewrite: 'GET /*.$1'}
  */
 module.exports = exports = function(options) {
-  var specialStatusCodes = options.specialStatusCodes || [200, 201, 302, 304, 400, 404, 500, 502];
+  var specialStatusCodes = options.specialStatusCodes || [200, 201, 302, 304, 400, 401, 404, 500, 502];
   var rewriteRules = options.rules || [];
 
   var cloudCollector = collectCloudAPICall(options);

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -16,9 +16,13 @@ var instanceId = os.hostname() + ' ' + process.env.LC_APP_PORT;
  * @param {String=} options.className
  * @param {Number=300000} options.commitCycle
  * @param {Number=5000} options.realtimeCycle
+ * @param {Object[]=} options.rules
+ *          {match: /^GET \/(js|css).+/, ignore: true}
+ *          {match: /^GET \/(js|css).+/, rewrite: 'GET /*.$1'}
  */
 module.exports = exports = function(options) {
   var specialStatusCodes = options.specialStatusCodes || [200, 201, 302, 304, 400, 404, 500, 502];
+  var rewriteRules = options.rules || [];
 
   var nameOfStatusCode = function(code) {
     if (_.contains(specialStatusCodes, code))
@@ -58,14 +62,28 @@ module.exports = exports = function(options) {
         }
       }
 
+      urlPattern = req.method.toUpperCase() + ' ' + urlPattern;
+
+      if (rewriteRules.some(function(rule) {
+        if (urlPattern.match(rule.match)) {
+          if (rule.ignore)
+            return true;
+
+          urlPattern = urlPattern.replace(rule.match, rule.rewrite);
+        }
+      })) {
+        return; // some rule return ingore.
+      }
+
       var record = {
-        urlPattern: req.method.toUpperCase() + ' ' + urlPattern,
+        urlPattern: urlPattern,
         responseTime: responseTime
       };
 
       record[typeOfStatusCode(res.statusCode)] = 1;
       record[nameOfStatusCode(res.statusCode)] = 1;
 
+      debug('router: %s %s %sms', urlPattern, res.statusCode, responseTime);
       collector.putRecord(record);
     });
 

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -58,7 +58,7 @@ module.exports = exports = function(options) {
       var record = {
         urlPattern: req.method.toUpperCase() + ' ' + urlPattern,
         totalResponseTime: responseTime
-      }
+      };
 
       record[typeOfStatusCode(res.statusCode)] = 1;
 
@@ -88,7 +88,6 @@ exports.collectCloudAPICall = function(options) {
     counterFields: ['totalResponseTime', 'success', 'clientError', 'serverError'],
     beforeSave: function(grouped) {
       var requests = grouped.success + grouped.clientError + grouped.serverError;
-      console.log(grouped.totalResponseTime, requests)
       grouped.avgResponseTime = grouped.totalResponseTime / requests;
       grouped.instance = instanceId;
       delete grouped.totalResponseTime;
@@ -117,6 +116,9 @@ exports.collectCloudAPICall = function(options) {
     };
 
     promise.then(function(result, statusCode) {
+      if (record.urlPattern.match(/POST classes\/LeanEngine(ReponseLog|CloudAPI)/))
+        return;
+
       record.totalResponseTime = Date.now() - startedAt.getTime();
       record.success = 1;
       debug('cloudAPI: %s %s', record.urlPattern, statusCode);
@@ -162,11 +164,9 @@ function createCollector(options) {
     debug('commitToServer');
 
     _.each(bucket, function(grouped) {
-      var log = new Storage();
-
       (new Storage()).save(beforeSave(grouped), {
         success: function(log) {
-          debug('Save success: %s', log.get('groupByField'));
+          debug('Save success: %s', log.get(groupByField));
         },
         error: function(log ,err) {
           console.error(err);
@@ -181,7 +181,7 @@ function createCollector(options) {
     var grouped = bucket[record[groupByField]];
 
     if (!grouped) {
-      grouped = bucket[record[groupByField]] = {}
+      grouped = bucket[record[groupByField]] = {};
 
       grouped[groupByField] = record[groupByField];
 

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -1,0 +1,109 @@
+var onFinished = require('on-finished');
+var onHeaders = require('on-headers');
+var _;
+
+module.exports = function(options) {
+  _ = options.AV._;
+
+  var collector = createCollector({
+    AV: options.AV
+  });
+
+  return function statusLogger(req, res, next) {
+    req._lc_startedAt = new Date();
+
+    onHeaders(res, function() {
+      res._lc_startedAt = new Date();
+    });
+
+    onFinished(res, function(err) {
+      if (err) return console.error(err.stack);
+
+      var responseTime = null;
+
+      if (res._lc_startedAt)
+        responseTime = res._lc_startedAt.getTime() - req._lc_startedAt.getTime();
+
+      collector.putRecord({
+        url: req.originalUrl,
+        endedAt: new Date(),
+        statusCode: res.statusCode,
+        responseTime: responseTime
+      });
+    });
+
+    next();
+  };
+};
+
+function createCollector(options) {
+  var commitCycle = options.commitCycle || 60 * 1000;
+
+  var ReponseLog = options.AV.Object.extend('LeanEngineReponseLog');
+  var records = [];
+  var lastCommitTime = new Date();
+
+  var commitToServer = function() {
+    var groupedRecords = _.groupBy(records, function(record) {
+      return record.url;
+    });
+
+    records = [];
+    lastCommitTime = new Date();
+
+    _.each(groupedRecords, function(records, urlPattern) {
+      var log = new ReponseLog();
+
+      var fromTime = null;
+      var toTime = null;
+      var responseTimes = {};
+      var statusCodes = {};
+
+      records.forEach(function (record) {
+        if (!fromTime || record.endedAt < fromTime)
+          fromTime = record.endedAt;
+        if (!toTime || record.endedAt > toTime)
+          toTime = record.endedAt;
+
+        if (statusCodes[record.statusCode])
+          statusCodes[record.statusCode]++;
+        else
+          statusCodes[record.statusCode] = 1;
+
+        if (responseTimes[record.responseTime])
+          responseTimes[record.responseTime]++;
+        else
+          responseTimes[record.responseTime] = 1;
+      });
+
+      log.save({
+        from: fromTime,
+        to: toTime,
+        urlPattern: urlPattern,
+        responseTimes: responseTimes,
+        statusCodes: statusCodes
+      }, {
+        success: function() {
+          console.log('Save success', {
+            urlPattern: urlPattern,
+            statusCodes: statusCodes
+          });
+        },
+        error: function(log ,err) {
+          console.error(err.stack);
+        }
+      });
+    });
+  };
+
+  setInterval(function() {
+    if (Date.now() - lastCommitTime.getTime() > commitCycle)
+      commitToServer();
+  });
+
+  return {
+    putRecord: function(record) {
+      records.push(record);
+    }
+  }
+}

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -11,22 +11,26 @@ var os = require('os');
 var instanceId = os.hostname() + ' ' + process.env.LC_APP_PORT;
 
 /**
- * @param options.AV
+ * @param {AV} options.AV
+ * @param {Number[]=} options.specialStatusCodes
+ * @param {String=} options.className
+ * @param {Number=300000} options.commitCycle
+ * @param {Number=5000} options.realtimeCycle
  */
 module.exports = exports = function(options) {
-  var collector = createCollector({
-    AV: options.AV,
+  var specialStatusCodes = options.specialStatusCodes || [200, 201, 302, 304, 400, 404, 500, 502];
+
+  var nameOfStatusCode = function(code) {
+    if (_.contains(specialStatusCodes, code))
+      return 'status' + code;
+    else
+      return null;
+  };
+
+  var collector = createCollector(_.extend({
     className: 'LeanEngineReponseLog5Min',
-    groupByField: 'urlPattern',
-    counterFields: ['totalResponseTime', 'success', 'clientError', 'serverError', 'other'],
-    beforeSave: function(grouped) {
-      var requests = grouped.success + grouped.clientError + grouped.serverError + grouped.other;
-      grouped.avgResponseTime = grouped.totalResponseTime / requests;
-      grouped.instance = instanceId;
-      delete grouped.totalResponseTime;
-      return grouped;
-    }
-  });
+    counterFields: specialStatusCodes.map(nameOfStatusCode)
+  }, options));
 
   return function statusLogger(req, res, next) {
     req._lc_startedAt = new Date();
@@ -46,7 +50,6 @@ module.exports = exports = function(options) {
 
       if (req.route) {
         // 如果这个请求属于一个路由，则用路由路径替换掉 URL 中匹配的部分
-
         var regexp = pathToRegexp(req.route.path).toString().replace(/^\/\^/, '').replace(/\/i$/, '');
         var matched = urlPattern.match(new RegExp(regexp, 'i'));
 
@@ -57,10 +60,11 @@ module.exports = exports = function(options) {
 
       var record = {
         urlPattern: req.method.toUpperCase() + ' ' + urlPattern,
-        totalResponseTime: responseTime
+        responseTime: responseTime
       };
 
       record[typeOfStatusCode(res.statusCode)] = 1;
+      record[nameOfStatusCode(res.statusCode)] = 1;
 
       collector.putRecord(record);
     });
@@ -76,6 +80,9 @@ module.exports = exports = function(options) {
 
 /**
  * @param options.AV
+ * @param {String=} options.className
+ * @param {Number=300000} options.commitCycle
+ * @param {Number=5000} options.realtimeCycle
  */
 exports.collectCloudAPICall = function(options) {
   var AV = options.AV;
@@ -83,16 +90,7 @@ exports.collectCloudAPICall = function(options) {
 
   var collector = createCollector({
     AV: AV,
-    className: 'LeanEngineCloudAPI5Min',
-    groupByField: 'urlPattern',
-    counterFields: ['totalResponseTime', 'success', 'clientError', 'serverError'],
-    beforeSave: function(grouped) {
-      var requests = grouped.success + grouped.clientError + grouped.serverError;
-      grouped.avgResponseTime = grouped.totalResponseTime / requests;
-      grouped.instance = instanceId;
-      delete grouped.totalResponseTime;
-      return grouped;
-    }
+    className: 'LeanEngineCloudAPI5Min'
   });
 
   var generateUrl = function(route, className, objectId, method) {
@@ -119,12 +117,12 @@ exports.collectCloudAPICall = function(options) {
       if (record.urlPattern.match(/POST classes\/LeanEngine(ReponseLog|CloudAPI)/))
         return;
 
-      record.totalResponseTime = Date.now() - startedAt.getTime();
+      record.responseTime = Date.now() - startedAt.getTime();
       record.success = 1;
       debug('cloudAPI: %s %s', record.urlPattern, statusCode);
       collector.putRecord(record);
     }, function(err) {
-      record.totalResponseTime = Date.now() - startedAt.getTime();
+      record.responseTime = Date.now() - startedAt.getTime();
 
       if (err.code > 0)
         record.clientError = 1;
@@ -145,15 +143,11 @@ exports.collectCloudAPICall = function(options) {
  * @param {Number=300000} options.commitCycle
  * @param {Number=5000} options.realtimeCycle
  * @param {String[]} options.counterFields
- * @param {String} options.groupByField
- * @param {Function} options.beforeSave
  */
 function createCollector(options) {
   var commitCycle = options.commitCycle || 300000;
   var realtimeCycle = options.realtimeCycle || 5000;
-  var groupByField = options.groupByField;
-  var counterFields = options.counterFields;
-  var beforeSave = options.beforeSave;
+  var counterFields = _.union(['responseTime', 'success', 'clientError', 'serverError'], options.counterFields);
 
   var Storage = options.AV.Object.extend(options.className);
   var bucket = {};
@@ -161,29 +155,49 @@ function createCollector(options) {
   var events = new EventEmitter();
 
   var commitToServer = function() {
+    if (_.isEmpty(bucket))
+      return;
+
     debug('commitToServer');
 
-    _.each(bucket, function(grouped) {
-      (new Storage()).save(beforeSave(grouped), {
-        success: function(log) {
-          debug('Save success: %s', log.get(groupByField));
-        },
-        error: function(log ,err) {
-          console.error(err);
-        }
-      });
+    var totalResponseTime = 0;
+
+    var log = {
+      urls: _.map(bucket, function(urlStat) {
+        totalResponseTime += urlStat.responseTime;
+        urlStat.responseTime = urlStat.responseTime / requestCount(urlStat);
+        return urlStat;
+      }),
+      instance: instanceId
+    };
+
+    counterFields.forEach(function(field) {
+      log[field] = _.reduce(log.urls, function(memory, stat) {
+        return memory + stat[field];
+      }, 0);
+    });
+
+    log.responseTime = totalResponseTime / requestCount(log);
+
+    (new Storage()).save(log, {
+      success: function() {
+        debug('Save success %s', options.className);
+      },
+      error: function(log ,err) {
+        console.error(err);
+      }
     });
 
     bucket = {};
   };
 
   var putToBucket = function(bucket, record) {
-    var grouped = bucket[record[groupByField]];
+    var grouped = bucket[record.urlPattern];
 
     if (!grouped) {
-      grouped = bucket[record[groupByField]] = {};
+      grouped = bucket[record.urlPattern] = {};
 
-      grouped[groupByField] = record[groupByField];
+      grouped.urlPattern = record.urlPattern;
 
       counterFields.forEach(function(field) {
         grouped[field] = record[field] || 0;
@@ -230,6 +244,13 @@ function typeOfStatusCode(code) {
     return 'clientError';
   else if (code >= 500)
     return 'serverError';
-  else
-    return 'other';
+}
+
+function requestCount(urlStat) {
+  var result = 0;
+  ['success', 'clientError', 'serverError'].forEach(function(field) {
+    if (urlStat[field])
+      result += urlStat[field];
+  });
+  return result;
 }

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -6,13 +6,26 @@ var EventEmitter = require('events');
 var pathToRegexp = require('path-to-regexp');
 var debug = require('debug')('AV:statusLogger');
 var _ = require('underscore');
+var os = require('os');
+
+var instanceId = os.hostname() + ' ' + process.env.LC_APP_PORT;
 
 /**
  * @param options.AV
  */
-module.exports = function(options) {
+module.exports = exports = function(options) {
   var collector = createCollector({
-    AV: options.AV
+    AV: options.AV,
+    className: 'LeanEngineReponseLog5Min',
+    groupByField: 'urlPattern',
+    counterFields: ['totalResponseTime', 'success', 'clientError', 'serverError', 'other'],
+    beforeSave: function(grouped) {
+      var requests = grouped.success + grouped.clientError + grouped.serverError + grouped.other;
+      grouped.avgResponseTime = grouped.totalResponseTime / requests;
+      grouped.instance = instanceId;
+      delete grouped.totalResponseTime;
+      return grouped;
+    }
   });
 
   return function statusLogger(req, res, next) {
@@ -23,7 +36,7 @@ module.exports = function(options) {
     });
 
     onFinished(res, function(err) {
-      if (err) return console.error(err.stack);
+      if (err) return console.error(err);
 
       var responseTime = null;
       var urlPattern = req.originalUrl.replace(/\?.*/, '');
@@ -42,11 +55,14 @@ module.exports = function(options) {
         }
       }
 
-      collector.putRecord({
+      var record = {
         urlPattern: req.method.toUpperCase() + ' ' + urlPattern,
-        statusCode: res.statusCode,
-        responseTime: responseTime
-      });
+        totalResponseTime: responseTime
+      }
+
+      record[typeOfStatusCode(res.statusCode)] = 1;
+
+      collector.putRecord(record);
     });
 
     if (req.path == '/_lc_recent.json')
@@ -60,14 +76,84 @@ module.exports = function(options) {
 
 /**
  * @param options.AV
- * @param options.commitCycle
- * @param options.realtimeCycle
+ */
+exports.collectCloudAPICall = function(options) {
+  var AV = options.AV;
+  var originalRequest = AV._request;
+
+  var collector = createCollector({
+    AV: AV,
+    className: 'LeanEngineCloudAPI5Min',
+    groupByField: 'urlPattern',
+    counterFields: ['totalResponseTime', 'success', 'clientError', 'serverError'],
+    beforeSave: function(grouped) {
+      var requests = grouped.success + grouped.clientError + grouped.serverError;
+      console.log(grouped.totalResponseTime, requests)
+      grouped.avgResponseTime = grouped.totalResponseTime / requests;
+      grouped.instance = instanceId;
+      delete grouped.totalResponseTime;
+      return grouped;
+    }
+  });
+
+  var generateUrl = function(route, className, objectId, method) {
+    var url = method + ' ' + route;
+
+    if (className)
+      url += '/' + className;
+
+    if (objectId)
+      url += '/:id';
+
+    return url;
+  };
+
+  AV._request = function(route, className, objectId, method) {
+    var startedAt = new Date();
+    var promise = originalRequest.apply(AV, arguments);
+
+    var record = {
+      urlPattern: generateUrl(route, className, objectId, method)
+    };
+
+    promise.then(function(result, statusCode) {
+      record.totalResponseTime = Date.now() - startedAt.getTime();
+      record.success = 1;
+      debug('cloudAPI: %s %s', record.urlPattern, statusCode);
+      collector.putRecord(record);
+    }, function(err) {
+      record.totalResponseTime = Date.now() - startedAt.getTime();
+
+      if (err.code > 0)
+        record.clientError = 1;
+      else
+        record.serverError = 1;
+
+      debug('cloudAPI: %s Error %s', record.urlPattern, err.code);
+      collector.putRecord(record);
+    });
+
+    return promise;
+  };
+};
+
+/**
+ * @param {AV} options.AV
+ * @param {String} options.className
+ * @param {Number=300000} options.commitCycle
+ * @param {Number=5000} options.realtimeCycle
+ * @param {String[]} options.counterFields
+ * @param {String} options.groupByField
+ * @param {Function} options.beforeSave
  */
 function createCollector(options) {
   var commitCycle = options.commitCycle || 300000;
   var realtimeCycle = options.realtimeCycle || 5000;
+  var groupByField = options.groupByField;
+  var counterFields = options.counterFields;
+  var beforeSave = options.beforeSave;
 
-  var ReponseLog = options.AV.Object.extend('LeanEngineReponseLog5Min');
+  var Storage = options.AV.Object.extend(options.className);
   var bucket = {};
   var realtimeBucket = {};
   var events = new EventEmitter();
@@ -75,19 +161,15 @@ function createCollector(options) {
   var commitToServer = function() {
     debug('commitToServer');
 
-    _.each(bucket, function(stat) {
-      var log = new ReponseLog();
+    _.each(bucket, function(grouped) {
+      var log = new Storage();
 
-      var requests = stat.success + stat.clientError + stat.serverError + stat.other;
-      stat.avgResponseTime = stat.totalResponseTime / requests;
-      delete stat.totalResponseTime;
-
-      log.save(stat, {
+      (new Storage()).save(beforeSave(grouped), {
         success: function(log) {
-          console.log('Save success', log.attributes);
+          debug('Save success: %s', log.get('groupByField'));
         },
         error: function(log ,err) {
-          console.error(err.stack);
+          console.error(err);
         }
       });
     });
@@ -96,21 +178,22 @@ function createCollector(options) {
   };
 
   var putToBucket = function(bucket, record) {
-    var stat = bucket[record.urlPattern];
+    var grouped = bucket[record[groupByField]];
 
-    if (!stat) {
-      stat = bucket[record.urlPattern] = {
-        urlPattern: record.urlPattern,
-        totalResponseTime: 0,
-        success: 0,
-        clientError: 0,
-        serverError: 0,
-        other: 0
-      };
+    if (!grouped) {
+      grouped = bucket[record[groupByField]] = {}
+
+      grouped[groupByField] = record[groupByField];
+
+      counterFields.forEach(function(field) {
+        grouped[field] = record[field] || 0;
+      });
+    } else {
+      counterFields.forEach(function(field) {
+        if (record[field])
+          grouped[field] += record[field];
+      });
     }
-
-    stat[typeOfStatusCode(record.statusCode)]++;
-    stat.totalResponseTime += record.responseTime;
   };
 
   setInterval(function() {
@@ -118,7 +201,6 @@ function createCollector(options) {
   }, commitCycle);
 
   setInterval(function() {
-    debug('emit realtime');
     events.emit('realtime', realtimeBucket);
     realtimeBucket = {};
   }, realtimeCycle);
@@ -127,7 +209,6 @@ function createCollector(options) {
     on: events.on.bind(events),
 
     putRecord: function(record) {
-      debug('putRecord: %s %s %sms', record.urlPattern, record.statusCode, record.responseTime);
       putToBucket(bucket, record);
       putToBucket(realtimeBucket, record);
     },

--- a/lib/status-logger/index.js
+++ b/lib/status-logger/index.js
@@ -3,18 +3,17 @@
 var onFinished = require('on-finished');
 var onHeaders = require('on-headers');
 var EventEmitter = require('events');
-var _;
+var pathToRegexp = require('path-to-regexp');
+var _ = require('underscore');
 
 module.exports = function(options) {
-  _ = options.AV._;
-
   var collector = createCollector({
     AV: options.AV,
     commitCycle: 60000
   });
 
   var realtimeJSON = function(req, res) {
-    res.json(collector.recentRecords());
+    res.json(collector.recentStatistics());
   };
 
   return function statusLogger(req, res, next) {
@@ -28,12 +27,22 @@ module.exports = function(options) {
       if (err) return console.error(err.stack);
 
       var responseTime = null;
+      var urlPattern = req.originalUrl.replace(/\?.*/, '');
 
       if (res._lc_startedAt)
         responseTime = res._lc_startedAt.getTime() - req._lc_startedAt.getTime();
 
+      if (req.route) {
+        var regexp = pathToRegexp(req.route.path).toString().replace(/^\/\^/, '').replace(/\/i$/, '');
+        var matched = urlPattern.match(new RegExp(regexp, 'i'));
+
+        if (matched[0]) {
+          urlPattern = urlPattern.slice(0, matched.index) + req.route.path;
+        }
+      }
+
       collector.putRecord({
-        url: req.originalUrl,
+        urlPattern: req.method.toUpperCase() + ' ' + urlPattern,
         statusCode: res.statusCode,
         responseTime: responseTime
       });
@@ -50,7 +59,7 @@ function createCollector(options) {
   var commitCycle = options.commitCycle || 300000;
   var realtimeCycle = options.realtimeCycle || 5000;
 
-  var ReponseLog = options.AV.Object.extend('LeanEngineReponseLog');
+  var ReponseLog = options.AV.Object.extend('LeanEngineReponseLog5Min');
   var bucket = {};
   var realtimeBucket = {};
   var events = new EventEmitter();
@@ -76,6 +85,24 @@ function createCollector(options) {
     bucket = {};
   };
 
+  var putToBucket = function(bucket, record) {
+    var stat = bucket[record.urlPattern];
+
+    if (!stat) {
+      stat = bucket[record.urlPattern] = {
+        urlPattern: record.urlPattern,
+        totalResponseTime: 0,
+        success: 0,
+        clientError: 0,
+        serverError: 0,
+        other: 0
+      };
+    }
+
+    stat[typeOfStatusCode(record.statusCode)]++;
+    stat.totalResponseTime += record.responseTime;
+  };
+
   setInterval(function() {
     commitToServer();
   }, commitCycle);
@@ -88,23 +115,10 @@ function createCollector(options) {
   return {
     on: events.on.bind(events),
     putRecord: function(record) {
-      var stat = bucket[record.url];
-
-      if (!stat) {
-        stat = bucket[record.url] = {
-          urlPattern: record.url,
-          totalResponseTime: 0,
-          success: 0,
-          clientError: 0,
-          serverError: 0,
-          other: 0
-        };
-      }
-
-      stat[typeOfStatusCode(record.statusCode)]++;
-      stat.totalResponseTime += record.responseTime;
+      putToBucket(bucket, record);
+      putToBucket(realtimeBucket, record);
     },
-    recentRecords: function() {
+    recentStatistics: function() {
       return bucket;
     }
   };

--- a/lib/status-logger/public/index.html
+++ b/lib/status-logger/public/index.html
@@ -2,6 +2,18 @@
   <head></head>
   <body>
     <select id='routerSelect'></select>
+    <select id='routerStatusCodeSelect'>
+      <option></option>
+      <option>200</option>
+      <option>201</option>
+      <option>302</option>
+      <option>304</option>
+      <option>400</option>
+      <option>401</option>
+      <option>404</option>
+      <option>500</option>
+      <option>502</option>
+    </select>
     <div id="routerSuccessAndError" style="width:100%; height:400px;"></div>
     <div id="routerResponseTime" style="width:100%; height:400px;"></div>
     <div id="routerPie" style="width:50%; height:400px; float: left;"></div>

--- a/lib/status-logger/public/index.html
+++ b/lib/status-logger/public/index.html
@@ -1,0 +1,12 @@
+<html>
+  <head></head>
+  <body>
+    <div id="routerSuccessAndError" style="width:100%; height:400px;"></div>
+    <div id="responseTime" style="width:100%; height:400px;"></div>
+    <div id="routerPie" style="width:50%; height:400px; float: left;"></div>
+    <div id="statusPie" style="width:50%; height:400px; float: left;"></div>
+    <script src="http://cdn.staticfile.org/jquery/1.8.2/jquery.min.js"></script>
+    <script src="http://cdn.staticfile.org/highcharts/4.0.4/highcharts.js"></script>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/lib/status-logger/public/index.html
+++ b/lib/status-logger/public/index.html
@@ -1,10 +1,14 @@
 <html>
   <head></head>
   <body>
+    <select id='routerSelect'></select>
     <div id="routerSuccessAndError" style="width:100%; height:400px;"></div>
-    <div id="responseTime" style="width:100%; height:400px;"></div>
+    <div id="routerResponseTime" style="width:100%; height:400px;"></div>
     <div id="routerPie" style="width:50%; height:400px; float: left;"></div>
     <div id="statusPie" style="width:50%; height:400px; float: left;"></div>
+    <div id="cloudResponseTime" style="width:100%; height:400px; clear: both;"></div>
+    <div id="cloudPie" style="width:50%; height:400px; float: left;"></div>
+    <div id="cloudStatusPie" style="width:50%; height:400px; float: left;"></div>
     <script src="http://cdn.staticfile.org/jquery/1.8.2/jquery.min.js"></script>
     <script src="http://cdn.staticfile.org/highcharts/4.0.4/highcharts.js"></script>
     <script src="index.js"></script>

--- a/lib/status-logger/public/index.html
+++ b/lib/status-logger/public/index.html
@@ -18,7 +18,8 @@
     <div id="routerResponseTime" style="width:100%; height:400px;"></div>
     <div id="routerPie" style="width:50%; height:400px; float: left;"></div>
     <div id="statusPie" style="width:50%; height:400px; float: left;"></div>
-    <div id="cloudResponseTime" style="width:100%; height:400px; clear: both;"></div>
+    <div id="cloudSuccessAndError" style="width:100%; height:400px; clear: both;"></div>
+    <div id="cloudResponseTime" style="width:100%; height:400px;"></div>
     <div id="cloudPie" style="width:50%; height:400px; float: left;"></div>
     <div id="cloudStatusPie" style="width:50%; height:400px; float: left;"></div>
     <script src="http://cdn.staticfile.org/jquery/1.8.2/jquery.min.js"></script>

--- a/lib/status-logger/public/index.js
+++ b/lib/status-logger/public/index.js
@@ -1,50 +1,117 @@
 'use strict';
 
-$.get('initial.json', function(data) {
-  $('#routerSuccessAndError').highcharts({
-    title: {
-      text: '路由 成功／失败'
-    },
-    yAxis: {
-      title: {
-        text: '次数'
-      }
-    },
-    series: data.routerSuccessAndError
-  });
+loadInitialData();
 
-  $('#responseTime').highcharts({
+$(function() {
+  $('#routerSelect').change(function() {
+    loadInitialData({router: $('#routerSelect').val() || undefined});
+  });
+});
+
+function loadInitialData(options) {
+  $.get('initial.json', options, function(data) {
+    if (options === undefined) {
+      $('#routerSelect').html("<option></option>");
+      data.routers.forEach(function(name) {
+        $('#routerSelect').append($("<option></option>").attr("value", name).text(name));
+      });
+    }
+
+    Highcharts.setOptions({
+      global: {
+        useUTC: false
+      }
+    });
+
+    $('#routerSuccessAndError').highcharts({
+      title: {
+        text: '路由 成功／失败'
+      },
+      xAxis: {
+        type: 'datetime',
+      },
+      yAxis: {
+        title: {
+          text: '次数'
+        }
+      },
+      series: data.routerSuccessAndError
+    });
+
+    $('#routerResponseTime').highcharts({
       chart: {
         type: 'area'
       },
       title: {
-        text: '平均响应时间'
+        text: '路由平均响应时间'
+      },
+      xAxis: {
+        type: 'datetime',
       },
       yAxis: {
         title: {
           text: '时间（毫秒）'
         }
       },
-      series: data.responseTime
-  });
+      series: data.routerResponseTime
+    });
 
-  $('#routerPie').highcharts({
-    chart: {
-      type: 'pie'
-    },
-    title: {
-      text: '路由分布'
-    },
-    series: data.routerPie
-  });
+    $('#cloudResponseTime').highcharts({
+      chart: {
+        type: 'area'
+      },
+      title: {
+        text: '云调用平均响应时间'
+      },
+      xAxis: {
+        type: 'datetime',
+      },
+      yAxis: {
+        title: {
+          text: '时间（毫秒）'
+        }
+      },
+      series: data.cloudResponseTime
+    });
 
-  $('#statusPie').highcharts({
-    chart: {
-      type: 'pie'
-    },
-    title: {
-      text: '响应代码分布'
-    },
-    series: data.statusPie
+    $('#routerPie').highcharts({
+      chart: {
+        type: 'pie'
+      },
+      title: {
+        text: '路由分布'
+      },
+      series: data.routerPie
+    });
+
+    $('#statusPie').highcharts({
+      chart: {
+        type: 'pie'
+      },
+      title: {
+        text: '响应代码分布'
+      },
+      series: data.statusPie
+    });
+
+    $('#cloudPie').highcharts({
+      chart: {
+        type: 'pie'
+      },
+      title: {
+        text: '云调用分布'
+      },
+      series: data.cloudPie
+    });
+
+    $('#cloudStatusPie').highcharts({
+      chart: {
+        type: 'pie'
+      },
+      title: {
+        text: '云调用响应分布'
+      },
+      series: data.cloudStatusPie
+    });
   });
-});
+}

--- a/lib/status-logger/public/index.js
+++ b/lib/status-logger/public/index.js
@@ -5,6 +5,12 @@ loadInitialData();
 $(function() {
   $('#routerSelect').change(function() {
     loadInitialData({router: $('#routerSelect').val() || undefined});
+    $('#routerStatusCodeSelect').val('')
+  });
+
+  $('#routerStatusCodeSelect').change(function() {
+    loadInitialData({routerStatusCode: $('#routerStatusCodeSelect').val() || undefined});
+    $('#routerSelect').val('')
   });
 });
 
@@ -25,7 +31,7 @@ function loadInitialData(options) {
 
     $('#routerSuccessAndError').highcharts({
       title: {
-        text: '路由 成功／失败'
+        text: '路由访问次数'
       },
       xAxis: {
         type: 'datetime',

--- a/lib/status-logger/public/index.js
+++ b/lib/status-logger/public/index.js
@@ -44,6 +44,21 @@ function loadInitialData(options) {
       series: data.routerSuccessAndError
     });
 
+    $('#cloudSuccessAndError').highcharts({
+      title: {
+        text: '云调用次数'
+      },
+      xAxis: {
+        type: 'datetime',
+      },
+      yAxis: {
+        title: {
+          text: '次数'
+        }
+      },
+      series: data.cloudSuccessAndError
+    });
+
     $('#routerResponseTime').highcharts({
       chart: {
         type: 'area'

--- a/lib/status-logger/public/index.js
+++ b/lib/status-logger/public/index.js
@@ -1,0 +1,50 @@
+'use strict';
+
+$.get('initial.json', function(data) {
+  $('#routerSuccessAndError').highcharts({
+    title: {
+      text: '路由 成功／失败'
+    },
+    yAxis: {
+      title: {
+        text: '次数'
+      }
+    },
+    series: data.routerSuccessAndError
+  });
+
+  $('#responseTime').highcharts({
+      chart: {
+        type: 'area'
+      },
+      title: {
+        text: '平均响应时间'
+      },
+      yAxis: {
+        title: {
+          text: '时间（毫秒）'
+        }
+      },
+      series: data.responseTime
+  });
+
+  $('#routerPie').highcharts({
+    chart: {
+      type: 'pie'
+    },
+    title: {
+      text: '路由分布'
+    },
+    series: data.routerPie
+  });
+
+  $('#statusPie').highcharts({
+    chart: {
+      type: 'pie'
+    },
+    title: {
+      text: '响应代码分布'
+    },
+    series: data.statusPie
+  });
+});

--- a/lib/status-logger/server.js
+++ b/lib/status-logger/server.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var basicAuth = require('basic-auth')
+var express = require('express');
+var _ = require('underscore');
+
+module.exports = function(options) {
+  var routerCollector = options.routerCollector;
+  var AV = options.AV;
+
+  var router = new express.Router();
+
+  var authenticate = function(req, res, next) {
+    var credentials = basicAuth(req);
+
+    if (credentials && credentials.name == AV.applicationId && credentials.pass == AV.masterKey) {
+      next();
+    } else {
+      res.header('WWW-Authenticate', 'Basic');
+      res.status(401).json({
+        code: 401, error: "Unauthorized."
+      });
+    }
+  }
+
+  router.use('/__lcStatusLogger', authenticate, express.static(__dirname + '/public'));
+
+  router.use('/__lcStatusLogger/initial.json', authenticate, function(req, res) {
+    var result = {
+      routerSuccessAndError: [],
+      responseTime: [],
+      routerPie: [],
+      statusPie: []
+    };
+
+    routerCollector.getLastDayStatistics().then(function(data) {
+      result.routerSuccessAndError.push({
+        name: 'success',
+        data: data.map(function(log) {
+          return log.get('success');
+        })
+      }, {
+        name: 'clientError',
+        data: data.map(function(log) {
+          return log.get('clientError');
+        })
+      }, {
+        name: 'serverError',
+        data: data.map(function(log) {
+          return log.get('serverError');
+        })
+      });
+
+      result.responseTime.push({
+        name: 'Router',
+        data: data.map(function(log) {
+          return log.get('responseTime');
+        })
+      });
+
+      var routerPie = {
+        name: 'Routers',
+        data: []
+      };
+
+      data.forEach(function(log) {
+        log.get('urls').forEach(function(url) {
+          if (_.findWhere(routerPie.data, {name: url.urlPattern})){
+            _.findWhere(routerPie.data, {name: url.urlPattern}).y += url.success + url.clientError + url.serverError;
+          } else {
+            routerPie.data.push({
+              name: url.urlPattern,
+              y: url.success + url.clientError + url.serverError
+            });
+          }
+        });
+      });
+
+      result.routerPie.push(routerPie);
+
+      var statusPie = {
+        name: 'StatusCode',
+        data: []
+      };
+
+      data.forEach(function(log) {
+        log.get('urls').forEach(function(url) {
+          _.each(url, function(value, key) {
+            if (isFinite(parseInt(key))) {
+              if (_.findWhere(statusPie.data, {name: key})) {
+                _.findWhere(statusPie.data, {name: key}).y += value;
+              } else {
+                statusPie.data.push({
+                  name: key,
+                  y: value
+                });
+              }
+            }
+          });
+        });
+      });
+
+      result.statusPie.push(statusPie);
+
+      res.json(result);
+    });
+  });
+
+  return router;
+};

--- a/lib/status-logger/server.js
+++ b/lib/status-logger/server.js
@@ -59,31 +59,45 @@ module.exports = function(options) {
           }));
         }
 
-        result.routerSuccessAndError.push({
-          name: 'success',
-          data: routerData.map(function(log) {
-            return {
-              x: log.createdAt.getTime(),
-              y: log.get('success')
-            };
-          })
-        }, {
-          name: 'clientError',
-          data: routerData.map(function(log) {
-            return {
-              x: log.createdAt.getTime(),
-              y: log.get('clientError')
-            };
-          })
-        }, {
-          name: 'serverError',
-          data: routerData.map(function(log) {
-            return {
-              x: log.createdAt.getTime(),
-              y: log.get('serverError')
-            };
-          })
-        });
+        if (!req.query.routerStatusCode) {
+          result.routerSuccessAndError.push({
+            name: 'success',
+            data: routerData.map(function(log) {
+              return {
+                x: log.createdAt.getTime(),
+                y: log.get('success')
+              };
+            })
+          }, {
+            name: 'clientError',
+            data: routerData.map(function(log) {
+              return {
+                x: log.createdAt.getTime(),
+                y: log.get('clientError')
+              };
+            })
+          }, {
+            name: 'serverError',
+            data: routerData.map(function(log) {
+              return {
+                x: log.createdAt.getTime(),
+                y: log.get('serverError')
+              };
+            })
+          });
+        } else {
+          result.routerSuccessAndError.push({
+            name: req.query.routerStatusCode,
+            data: routerData.map(function(log) {
+              return {
+                x: log.createdAt.getTime(),
+                y: log.get('urls').reduce(function(previous, url) {
+                  return previous + url[req.query.routerStatusCode];
+                }, 0)
+              };
+            })
+          });
+        }
 
         result.routerResponseTime.push({
           name: 'Router',
@@ -112,8 +126,15 @@ module.exports = function(options) {
 
         routerData.forEach(function(log) {
           log.get('urls').forEach(function(url) {
-            if (_.findWhere(routerPie.data, {name: url.urlPattern})){
-              _.findWhere(routerPie.data, {name: url.urlPattern}).y += url.success + url.clientError + url.serverError;
+            if (_.findWhere(routerPie.data, {name: url.urlPattern})) {
+              var y;
+
+              if (req.query.routerStatusCode)
+                y = url[req.query.routerStatusCode];
+              else
+                y = url.success + url.clientError + url.serverError;
+
+              _.findWhere(routerPie.data, {name: url.urlPattern}).y += y;
             } else {
               routerPie.data.push({
                 name: url.urlPattern,

--- a/lib/status-logger/server.js
+++ b/lib/status-logger/server.js
@@ -35,6 +35,7 @@ module.exports = function(options) {
       cloudResponseTime: [],
       routerPie: [],
       statusPie: [],
+      cloudSuccessAndError: [],
       cloudPie: [],
       cloudStatusPie: []
     };
@@ -105,6 +106,32 @@ module.exports = function(options) {
             return {
               x: log.createdAt.getTime(),
               y: log.get('responseTime')
+            };
+          })
+        });
+
+        result.cloudSuccessAndError.push({
+          name: 'success',
+          data: cloudData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('success')
+            };
+          })
+        }, {
+          name: 'clientError',
+          data: cloudData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('clientError')
+            };
+          })
+        }, {
+          name: 'serverError',
+          data: cloudData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('serverError')
             };
           })
         });

--- a/lib/status-logger/server.js
+++ b/lib/status-logger/server.js
@@ -1,11 +1,14 @@
 'use strict';
 
-var basicAuth = require('basic-auth')
+var basicAuth = require('basic-auth');
 var express = require('express');
 var _ = require('underscore');
 
+var responseTypes = ['success', 'clientError', 'serverError'];
+
 module.exports = function(options) {
   var routerCollector = options.routerCollector;
+  var cloudCollector = options.cloudCollector;
   var AV = options.AV;
 
   var router = new express.Router();
@@ -21,88 +24,177 @@ module.exports = function(options) {
         code: 401, error: "Unauthorized."
       });
     }
-  }
+  };
 
   router.use('/__lcStatusLogger', authenticate, express.static(__dirname + '/public'));
 
   router.use('/__lcStatusLogger/initial.json', authenticate, function(req, res) {
     var result = {
       routerSuccessAndError: [],
-      responseTime: [],
+      routerResponseTime: [],
+      cloudResponseTime: [],
       routerPie: [],
-      statusPie: []
+      statusPie: [],
+      cloudPie: [],
+      cloudStatusPie: []
     };
 
-    routerCollector.getLastDayStatistics().then(function(data) {
-      result.routerSuccessAndError.push({
-        name: 'success',
-        data: data.map(function(log) {
-          return log.get('success');
-        })
-      }, {
-        name: 'clientError',
-        data: data.map(function(log) {
-          return log.get('clientError');
-        })
-      }, {
-        name: 'serverError',
-        data: data.map(function(log) {
-          return log.get('serverError');
-        })
-      });
-
-      result.responseTime.push({
-        name: 'Router',
-        data: data.map(function(log) {
-          return log.get('responseTime');
-        })
-      });
-
-      var routerPie = {
-        name: 'Routers',
-        data: []
-      };
-
-      data.forEach(function(log) {
-        log.get('urls').forEach(function(url) {
-          if (_.findWhere(routerPie.data, {name: url.urlPattern})){
-            _.findWhere(routerPie.data, {name: url.urlPattern}).y += url.success + url.clientError + url.serverError;
-          } else {
-            routerPie.data.push({
-              name: url.urlPattern,
-              y: url.success + url.clientError + url.serverError
+    routerCollector.getLastDayStatistics().then(function(routerData) {
+      cloudCollector.getLastDayStatistics().then(function(cloudData) {
+        if (req.query.router) {
+          routerData = _.compact(routerData.map(function(log) {
+            log.set({
+              urls: [_.findWhere(log.get('urls'), {urlPattern: req.query.router})]
             });
-          }
+
+            if (_.isEmpty(log.get('urls')) || !log.get('urls')[0]) {
+              return null;
+            } else {
+              responseTypes.forEach(function(type) {
+                log.set(type, log.get('urls')[0][type]);
+              });
+              log.set('responseTime', log.get('urls')[0].responseTime);
+              return log;
+            }
+          }));
+        }
+
+        result.routerSuccessAndError.push({
+          name: 'success',
+          data: routerData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('success')
+            };
+          })
+        }, {
+          name: 'clientError',
+          data: routerData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('clientError')
+            };
+          })
+        }, {
+          name: 'serverError',
+          data: routerData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('serverError')
+            };
+          })
         });
-      });
 
-      result.routerPie.push(routerPie);
+        result.routerResponseTime.push({
+          name: 'Router',
+          data: routerData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('responseTime')
+            };
+          })
+        });
 
-      var statusPie = {
-        name: 'StatusCode',
-        data: []
-      };
+        result.cloudResponseTime.push({
+          name: 'Cloud',
+          data: cloudData.map(function(log) {
+            return {
+              x: log.createdAt.getTime(),
+              y: log.get('responseTime')
+            };
+          })
+        });
 
-      data.forEach(function(log) {
-        log.get('urls').forEach(function(url) {
-          _.each(url, function(value, key) {
-            if (isFinite(parseInt(key))) {
-              if (_.findWhere(statusPie.data, {name: key})) {
-                _.findWhere(statusPie.data, {name: key}).y += value;
-              } else {
-                statusPie.data.push({
-                  name: key,
-                  y: value
-                });
-              }
+        var routerPie = {
+          name: 'Routers',
+          data: []
+        };
+
+        routerData.forEach(function(log) {
+          log.get('urls').forEach(function(url) {
+            if (_.findWhere(routerPie.data, {name: url.urlPattern})){
+              _.findWhere(routerPie.data, {name: url.urlPattern}).y += url.success + url.clientError + url.serverError;
+            } else {
+              routerPie.data.push({
+                name: url.urlPattern,
+                y: url.success + url.clientError + url.serverError
+              });
             }
           });
         });
+
+        result.routerPie.push(routerPie);
+
+        var statusPie = {
+          name: 'StatusCode',
+          data: []
+        };
+
+        routerData.forEach(function(log) {
+          log.get('urls').forEach(function(url) {
+            _.each(url, function(value, key) {
+              if (isFinite(parseInt(key))) {
+                if (_.findWhere(statusPie.data, {name: key})) {
+                  _.findWhere(statusPie.data, {name: key}).y += value;
+                } else {
+                  statusPie.data.push({
+                    name: key,
+                    y: value
+                  });
+                }
+              }
+            });
+          });
+        });
+
+        result.statusPie.push(statusPie);
+
+        var cloudPie = {
+          name: 'Cloud',
+          data: []
+        };
+
+        cloudData.forEach(function(log) {
+          log.get('urls').forEach(function(url) {
+            if (_.findWhere(cloudPie.data, {name: url.urlPattern})){
+              _.findWhere(cloudPie.data, {name: url.urlPattern}).y += url.success + url.clientError + url.serverError;
+            } else {
+              cloudPie.data.push({
+                name: url.urlPattern,
+                y: url.success + url.clientError + url.serverError
+              });
+            }
+          });
+        });
+
+        result.cloudPie.push(cloudPie);
+
+        var cloudStatusPie = {
+          name: 'StatusCode',
+          data: []
+        };
+
+        cloudData.forEach(function(log) {
+          log.get('urls').forEach(function(url) {
+            responseTypes.forEach(function(type) {
+              if (_.findWhere(cloudStatusPie.data, {name: type})) {
+                _.findWhere(cloudStatusPie.data, {name: type}).y += url[type];
+              } else {
+                cloudStatusPie.data.push({
+                  name: type,
+                  y: url[type]
+                });
+              }
+            });
+          });
+        });
+
+        result.cloudStatusPie.push(cloudStatusPie);
+
+        result.routers = _.pluck(result.routerPie[0].data, 'name');
+
+        res.json(result);
       });
-
-      result.statusPie.push(statusPie);
-
-      res.json(result);
     });
   });
 

--- a/lib/status-logger/server.js
+++ b/lib/status-logger/server.js
@@ -126,19 +126,19 @@ module.exports = function(options) {
 
         routerData.forEach(function(log) {
           log.get('urls').forEach(function(url) {
+            var y;
+
+            if (req.query.routerStatusCode)
+              y = url[req.query.routerStatusCode];
+            else
+              y = url.success + url.clientError + url.serverError;
+
             if (_.findWhere(routerPie.data, {name: url.urlPattern})) {
-              var y;
-
-              if (req.query.routerStatusCode)
-                y = url[req.query.routerStatusCode];
-              else
-                y = url.success + url.clientError + url.serverError;
-
               _.findWhere(routerPie.data, {name: url.urlPattern}).y += y;
-            } else {
+            } else if (y > 0) {
               routerPie.data.push({
                 name: url.urlPattern,
-                y: url.success + url.clientError + url.serverError
+                y: y
               });
             }
           });
@@ -157,7 +157,7 @@ module.exports = function(options) {
               if (isFinite(parseInt(key))) {
                 if (_.findWhere(statusPie.data, {name: key})) {
                   _.findWhere(statusPie.data, {name: key}).y += value;
-                } else {
+                } else if (value > 0) {
                   statusPie.data.push({
                     name: key,
                     y: value

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "avoscloud-sdk": "0.x",
+    "basic-auth": "1.0.3",
     "body-parser": "1.9.0",
     "connect": "3.2.0",
     "cookies": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "cookies": "0.5.0",
     "debug": "2.0.0",
     "iconv-lite": "^0.4.8",
+    "on-finished": "^2.3.0",
     "on-headers": "1.0.0",
     "path-to-regexp": "^1.2.1",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "cookies": "0.5.0",
     "debug": "2.0.0",
     "iconv-lite": "^0.4.8",
-    "on-headers": "1.0.0"
+    "on-headers": "1.0.0",
+    "path-to-regexp": "^1.2.1",
+    "underscore": "^1.8.3"
   },
   "devDependencies": {
     "blanket": "1.1.6",


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1191561/10601443/71b0e49c-7744-11e5-801f-6afd50279e51.png)

把它们写在了一起，因为它们上传的逻辑是一样的，只是采集的数据不一样。`createCollector` 返回一个抽象的收集器，用来执行这几个逻辑：
- 对 `putRecord` 传入的数据按指定的字段（通常 URL）分组，然后去更新其他的计数器（如失败次数、响应时间）
- 保留短期数据，每五秒清空一次，会触发一个事件，届时会用 websocket 监听这个事件并发给客户端。
- 每五分将数据储存到云储存的一个类里面，储存之前会计算平均响应时间、加上实例名（hostname+port）

路由的统计是一个 express 中间件，从 req 对象中得到对应的路由（Route），目前只能提取在定义路由的时候提供的参数（`router.post '/todos/:id/done'`），在中间件中被直接处理的 URL 目前还是完整的 URL（比如 serve-static 处理的静态文件）。

云储存 API 调用的统计是重写了 AV._request, 将 method, route, className 几个参数拼成一个伪 URL, 以便进行分组。

用法很简单，只要加上：

```
var statusLogger = require('leanengine/lib/status-logger');
app.use(statusLogger({AV: AV})); // 路由统计
```

https://github.com/leancloud/leanengine-node-sdk/issues/34
