### PR TITLE
增加 disableHook 的 API 

### DIFF
--- a/lib/av-extra.js
+++ b/lib/av-extra.js
@@ -284,4 +284,12 @@ AV.Cloud.httpRequest = function(options) {
   return promise._thenRunCallbacks(options);
 };
 
+AV.Object.prototype.disableBeforeHook = function() {
+  this.set('__before', new Date().getTime());
+};
+
+AV.Object.prototype.disableAfterHook = function() {
+  this.set('__after', new Date().getTime());
+};
+
 module.exports = AV;

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -342,22 +342,6 @@ var call = function(funcName, params, user, meta, options, cb) {
   }
 };
 
-var hookMarks = [
-  '__before',
-  '__after_update',
-  '__after'
-];
-
-// 如果对象有 hook 标记，则需要明确 set 一次，标记才会保存在 changed 列表
-// 这样调用 REST API 时才会将标记一同传到存储服务端
-var setHookMark = function (obj) {
-  hookMarks.forEach(function(hookMark) {
-    if (obj.get(hookMark)) {
-      obj.set(hookMark, obj.get(hookMark));
-    }
-  });
-};
-
 var classHook = function(className, hook, object, user, meta, cb) {
   if (!Cloud.__code[hook + className]) {
     var err = new Error("LeanEngine not found hook '" + hook + className +  "' for app '" + AV.applicationId + "' on " + NODE_ENV + ".");
@@ -375,9 +359,9 @@ var classHook = function(className, hook, object, user, meta, cb) {
     obj.updatedKeys = object._updatedKeys;
   }
 
-  setHookMark(obj);
   try {
     if (hook.indexOf('__after_') === 0) {
+      obj.disableAfterHook();
       // after 的 hook 不需要 response 参数，并且请求默认返回 ok
       Cloud.__code[hook + className]({
         user: user,
@@ -386,6 +370,7 @@ var classHook = function(className, hook, object, user, meta, cb) {
       });
       return cb(null, 'ok');
     } else {
+      obj.disableBeforeHook();
       Cloud.__code[hook + className]({
         user: user,
         object: obj

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -510,21 +510,20 @@ AV.Insight.on = function(action, func) {
 };
 
 Cloud.logInByIdAndSessionToken = function(uid, sessionToken, fetch, cb) {
-  var user;
-  user = new AV.User();
-  user.id = uid;
-  user._sessionToken = sessionToken;
-  AV.User._saveCurrentUser(user);
   if (fetch) {
-    return user.fetch({
+    AV.User.become(sessionToken, {
       success: function(user) {
         return cb(null, user);
       },
-      error: function(err) {
+      error: function(user, err) {
         return cb(err);
       }
     });
   } else {
+    var user = new AV.User();
+    user.id = uid;
+    user._sessionToken = sessionToken;
+    AV.User._saveCurrentUser(user);
     return cb(null, user);
   }
 };

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -61,7 +61,7 @@ AV.Cloud.define('bareAVObject', function(request, response) {
     success: function(results) {
       response.success(results[0]);
     }
-  })
+  });
 });
 
 AV.Cloud.define('AVObjects', function(request, response) {
@@ -174,7 +174,7 @@ AV.Cloud.define('testRunWithAVObject', function(request, response) {
      response.success(datas);
    }
  });
-})
+});
 
 AV.Cloud.define('readDir', function(request, response) {
   fs.readdir('.', function(err, dir) {
@@ -314,7 +314,7 @@ describe('functions', function() {
         });
 
         done();
-      })
+      });
   });
 
   // 返回单个 AVObject
@@ -374,7 +374,7 @@ describe('functions', function() {
           name: 'avObjects'
         }]
       })
-      .expect(200, function(err, res) {
+      .expect(200, function(err) {
         done(err);
       });
   });
@@ -395,7 +395,7 @@ describe('functions', function() {
           name: 'hello.txt'
         },
       })
-      .expect(200, function(err, res) {
+      .expect(200, function(err) {
         done(err);
       });
   });
@@ -418,7 +418,7 @@ describe('functions', function() {
       .set('X-AVOSCloud-Application-Id', appId)
       .set('X-AVOSCloud-Application-Key', appKey)
       .send([object, object])
-      .expect(200, function(err, res) {
+      .expect(200, function(err) {
         done(err);
       });
   });
@@ -442,7 +442,7 @@ describe('functions', function() {
        res.body.result.avObjects[0].__type.should.equal('Object');
        res.body.result.avObjects[0].className.should.equal('ComplexObject');
        done();
-     })
+     });
   });
 
   it('testRun_text_plain', function(done) {
@@ -587,36 +587,29 @@ describe('functions', function() {
         return done();
       }
     };
+    var doRequest = function(sessionToken, username, cb) {
+      var r = request(AV.Cloud)
+        .post('/1.1/functions/userMatching')
+        .set('X-AVOSCloud-Application-Id', appId)
+        .set('X-AVOSCloud-Application-Key', appKey);
+      if (sessionToken) {
+        r.set('X-AVOSCloud-session-token', sessionToken);
+      }
+      r.end(function(err, res) {
+          if (username) {
+            res.body.result.reqUser.username.should.equal(username);
+            res.body.result.currentUser.username.should.equal(username);
+          } else {
+            should.not.exist(res.body.reqUser);
+            should.not.exist(res.body.currentUser);
+          }
+          return cb(err);
+      });
+    };
     for (var i = 0; i <= 4; i++) {
-      request(AV.Cloud)
-        .post('/1.1/functions/userMatching')
-        .set('X-AVOSCloud-Application-Id', appId)
-        .set('X-AVOSCloud-Application-Key', appKey)
-        .set('X-AVOSCloud-session-token', sessionToken_admin)
-        .expect(200, function(err, res) {
-          res.body.result.reqUser.username.should.equal('admin');
-          res.body.result.currentUser.username.should.equal('admin');
-          return cb(err);
-      });
-      request(AV.Cloud)
-        .post('/1.1/functions/userMatching')
-        .set('X-AVOSCloud-Application-Id', appId)
-        .set('X-AVOSCloud-Application-Key', appKey)
-        .set('X-AVOSCloud-session-token', '3267fscy0q4g3i4yc9uq9rqqv')
-        .expect(200, function(err, res) {
-          res.body.result.reqUser.username.should.equal('zhangsan');
-          res.body.result.currentUser.username.should.equal('zhangsan');
-          return cb(err);
-      });
-      request(AV.Cloud)
-        .post('/1.1/functions/userMatching')
-        .set('X-AVOSCloud-Application-Id', appId)
-        .set('X-AVOSCloud-Application-Key', appKey)
-        .expect(200, function(err, res) {
-          should.not.exist(res.body.reqUser);
-          should.not.exist(res.body.currentUser);
-          return cb(err);
-      });
+      doRequest(sessionToken_admin, 'admin', cb);
+      doRequest('0hgr13u12tmgyv4x594682sv5', 'zhangsan', cb);
+      doRequest(null, null, cb);
     }
   });
 

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -50,7 +50,7 @@ AV.Cloud.define('complexObject', function(request, response) {
         avObjects: results,
       });
     }
-  })
+  });
 });
 
 AV.Cloud.define('bareAVObject', function(request, response) {
@@ -72,7 +72,7 @@ AV.Cloud.define('AVObjects', function(request, response) {
     success: function(results) {
       response.success(results);
     }
-  })
+  });
 });
 
 AV.Cloud.define('testAVObjectParams', function(request, response) {

--- a/test/hook_test.js
+++ b/test/hook_test.js
@@ -69,6 +69,7 @@ AV.Cloud.afterSave("TestError", function() {
 
 AV.Cloud.afterUpdate("TestClass", function(request) {
   var bizTime = new Date();
+  assert(request.object.updatedKeys.indexOf('foo') != -1);
   request.object.set('bizTime', bizTime);
   request.object.save(null, {
     success: function(obj) {
@@ -343,6 +344,7 @@ describe('hook', function() {
     .set('Content-Type', 'application/json')
     .send({
       object: {
+        "_updatedKeys": ['foo'],
         objectId: '556904d8e4b09419960c14bd',
         foo: 'bar'
       }

--- a/test/hook_test.js
+++ b/test/hook_test.js
@@ -54,7 +54,7 @@ AV.Cloud.beforeSave("ErrorObject", function(request, response) {
 });
 
 AV.Cloud.beforeSave('ContainsFile', function(request, response) {
-  request.object.get('file').url().should.be.equal('http://ac-4h2h4okw.clouddn.com/4qSbLMO866Tf4YtT9QEwJwysTlHGC9sMl7bpTwhQ.jpg')
+  request.object.get('file').url().should.be.equal('http://ac-4h2h4okw.clouddn.com/4qSbLMO866Tf4YtT9QEwJwysTlHGC9sMl7bpTwhQ.jpg');
   response.success();
 });
 
@@ -118,10 +118,12 @@ describe('hook', function() {
           }
       })
       .expect(200)
-      .expect({
-        "stars": 1,
-        "comment": "12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567..."
-      }, done);
+      .end(function(err, res) {
+        res.body.stars.should.equal(1);
+        res.body.comment.should.equal('12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567...');
+        should.exist(res.body.__before);
+        done();
+      });
   });
 
   it('beforeSave_ContainsFile', function(done) {
@@ -139,7 +141,7 @@ describe('hook', function() {
             }
           }
       })
-      .expect(200, done)
+      .expect(200, done);
   });
 
   it('beforeSave_error', function(done) {
@@ -175,13 +177,15 @@ describe('hook', function() {
         "object": {}
       })
       .expect(200)
-      .expect({
-        "user": {
+      .end(function(err, res) {
+        res.body.user.should.eql({
           "__type": "Pointer",
           "className": "_User",
           "objectId": "52aebbdee4b0c8b6fa455aa7"
-        }
-      }, done);
+        });
+        should.exist(res.body.__before);
+        done();
+      });
   });
 
   it("beforeSave_throw_error", function(done) {


### PR DESCRIPTION
为了防止 Hook 函数死循环调用，增加相关 API。默认情况下 request.object 会自动设置，如果用户自行创建了对象（比如对象重新 fetch 或者 createWithoutData 创建对象），为了避免循环调用，需要明确的调用该 API。
