### PR TITLE
fix: disableHook API 增加签名机制

### DIFF
--- a/lib/av-extra.js
+++ b/lib/av-extra.js
@@ -7,6 +7,7 @@ var qs = require('querystring');
 var iconvlite = require('iconv-lite');
 var AV = require('avoscloud-sdk').AV;
 var utils = require('./utils');
+var crypto = require('crypto');
 var debug = require('debug')('AV:LeanEngine');
 var version = require('../package.json').version;
 
@@ -285,11 +286,19 @@ AV.Cloud.httpRequest = function(options) {
 };
 
 AV.Object.prototype.disableBeforeHook = function() {
-  this.set('__before', new Date().getTime());
+  this.set('__before', signDisableHook('__before_for_' + this.className, new Date().getTime()));
 };
 
 AV.Object.prototype.disableAfterHook = function() {
-  this.set('__after', new Date().getTime());
+  this.set('__after', signDisableHook('__after_for_' + this.className, new Date().getTime()));
+};
+
+var signDisableHook = function(hookName, ts) {
+  var masterKey = process.env.LC_APP_MASTER_KEY;
+  var sign = crypto.createHmac('sha1', masterKey)
+    .update(hookName + ':' + ts)
+    .digest('hex');
+  return ts + ',' + sign;
 };
 
 module.exports = AV;

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -361,7 +361,7 @@ var classHook = function(className, hook, object, user, meta, cb) {
 
   try {
     if (hook.indexOf('__after_') === 0) {
-      obj.disableAfterHook();
+      setHookMark('__after', obj);
       // after 的 hook 不需要 response 参数，并且请求默认返回 ok
       Cloud.__code[hook + className]({
         user: user,
@@ -370,7 +370,7 @@ var classHook = function(className, hook, object, user, meta, cb) {
       });
       return cb(null, 'ok');
     } else {
-      obj.disableBeforeHook();
+      setHookMark('__before', obj);
       Cloud.__code[hook + className]({
         user: user,
         object: obj
@@ -394,6 +394,19 @@ var classHook = function(className, hook, object, user, meta, cb) {
     }
     err.statusCode = 500;
     return cb(err);
+  }
+};
+
+var setHookMark = function(hookAction, obj) {
+  var sign = obj.get(hookAction);
+  if(sign) {
+    obj.set(hookAction, sign);
+  } else {
+    if(hookAction.indexOf('__before') === 0) {
+      obj.disableBeforeHook();
+    } else if(hookAction.indexOf('__after') === 0) {
+      obj.disableAfterHook();
+    }
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "expect.js ": "0.2.0",
     "express": "4.9.7",
     "mocha": "2.3.3",
+    "rewire": "^2.5.1",
     "should": "3.3.2",
     "supertest": "0.14.0"
   },

--- a/test/av-extra_test.js
+++ b/test/av-extra_test.js
@@ -1,6 +1,7 @@
 'use strict';
-var should = require('should'), // jshint ignore:line
-    AV = require('../lib/av-extra');
+var should = require('should'); // jshint ignore:line
+var rewire = require("rewire");
+var AV = rewire('../lib/av-extra.js');
 
 var express = require('express');
 var bodyParser = require('body-parser');
@@ -55,4 +56,9 @@ describe('av-extra', function() {
       }
     });
   });
+
+  it('signDisableHook', function() {
+    AV.__get__('signDisableHook')('__before_for_TestClass', 1453711871302).should.equal('1453711871302,177cbac6495f52e462aae2d054529e08a1725276');
+  });
+
 });


### PR DESCRIPTION
之前设置的值过于简单，导致请求容易被伪造，存在一定的
安全风险。
新的值会使用 masterKey 和时间签名，存储服务会校验值的
有效性，从而确定是否禁止触发 hook 函数。
