### PR TITLE
保留请求中的 __type 字段，以供 rpc 功能使用

### DIFF
--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -96,7 +96,8 @@ Cloud.use('/__engine/1/ping', function(req, res) {
         prodValue = req.body._ApplicationProduction;
         sessionToken = req.body._SessionToken;
         for (param in req.body) {
-          if (param.charAt(0) === '_') {
+          // remove _* but keep __*
+          if (param.charAt(0) === '_' && param.charAt(1) !== '_') {
             delete req.body[param];
           }
         }


### PR DESCRIPTION
似乎目前用于跨域参数的字段都是一个下划线开头（`_ApplicationId`、`_ApplicationKey`、`_ApplicationProduction`、`_ClientVersion`、`_InstallationId`），所以在此只去除一个下划线开头的字段，留下 `__type` 等参数供 rpc 功能使用。

@sdjcw @aisk @juvenn 需要检查 Python 和 PHP SDK 是否需要考虑这个问题。
