### PR TITLE
feat: Cloud 函数和 Hook 函数增加 15 秒超时时间限制

### DIFF
--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -4,6 +4,7 @@ var connect = require('connect'),
   https = require('https'),
   domain = require('domain'),
   crypto = require('crypto'),
+  timeout = require('connect-timeout'),
   version = require('../package.json').version,
   AV = require('./av-extra'),
   utils = require('./utils'),
@@ -30,6 +31,8 @@ if (!AV._old_Cloud) {
 if (https.globalAgent && https.globalAgent.options) {
   https.globalAgent.options.rejectUnauthorized = false;
 }
+
+var TIMEOUT = '15s';
 
 AV.Cloud.CookieSession = avosExpressCookieSession(AV);
 AV.Cloud.HttpsRedirect = avosExpressHttpsRedirect(AV);
@@ -59,6 +62,7 @@ Cloud.use('/__engine/1/ping', function(req, res) {
       next();
     });
 
+    Cloud.use(route, timeout(TIMEOUT));
     Cloud.use(route, bodyParser.urlencoded({extended: false}));
     Cloud.use(route, bodyParser.json());
     Cloud.use(route, bodyParser.text());
@@ -72,7 +76,7 @@ Cloud.use('/__engine/1/ping', function(req, res) {
       d.add(req);
       d.add(res);
       d.on('error', function(err) {
-        console.error('LeanEngine function uncaughtException url=%s, msg=%s', req.url, err.stack || err.message || err);
+        console.error('LeanEngine function uncaughtException url=%s, msg=%s', req.originalUrl, err.stack || err.message || err);
         if(!res.finished) {
           res.statusCode = 500;
           res.setHeader('content-type', 'application/json; charset=UTF-8');
@@ -261,6 +265,11 @@ Cloud.use('/__engine/1/ping', function(req, res) {
 
     // next 参数即使不使用，也一定要存在，否则 error handler 不生效
     Cloud.use(route, function(err, req, res, next) { // jshint ignore:line
+      if(req.timedout) {
+        console.error('LeanEngine function timeout, url=%s, timeout=%d', req.originalUrl, err.timeout);
+        err.code = 124; // https://leancloud.cn/docs/error_code.html#_124
+        err.message = 'The request timed out on the server.';
+      }
       respError(res, err);
     });
   });

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "avoscloud-sdk": "0.x",
     "body-parser": "1.9.0",
     "connect": "3.2.0",
+    "connect-timeout": "^1.7.0",
     "cookies": "0.5.0",
     "debug": "2.0.0",
     "iconv-lite": "^0.4.8",

--- a/test/function_test.js
+++ b/test/function_test.js
@@ -478,7 +478,6 @@ describe('functions', function() {
 
   // 测试带有 sessionToken 时，user 对象的正确解析
   it('testUser', function(done) {
-    this.timeout(5000);
     request(AV.Cloud)
       .post('/1/functions/testUser')
       .set('X-AVOSCloud-Application-Id', appId)
@@ -489,7 +488,6 @@ describe('functions', function() {
 
   // 无效 sessionToken 测试
   it('testUser_invalid_sessionToken', function(done) {
-    this.timeout(5000);
     request(AV.Cloud)
       .post('/1/functions/testUser')
       .set('X-AVOSCloud-Application-Id', appId)
@@ -504,7 +502,6 @@ describe('functions', function() {
 
   // 测试调用 run 方法时，传递 user 对象的有效性
   it('testRunWithUser', function(done) {
-    this.timeout(5000);
     request(AV.Cloud)
       .post('/1/functions/testRunWithUser')
       .set('X-AVOSCloud-Application-Id', appId)
@@ -515,7 +512,6 @@ describe('functions', function() {
 
   // 测试调用 run 方法 options callback
   it('testRun_options_callback', function(done) {
-    this.timeout(5000);
     request(AV.Cloud)
       .post('/1/functions/testRun_options_callback')
       .set('X-AVOSCloud-Application-Id', appId)
@@ -526,7 +522,6 @@ describe('functions', function() {
 
   // 测试调用 run 方法，返回值是 promise 类型
   it('testRun_promise', function(done) {
-    this.timeout(5000);
     request(AV.Cloud)
       .post('/1/functions/testRun_promise')
       .set('X-AVOSCloud-Application-Id', appId)


### PR DESCRIPTION
因为 Node.js 存在大量的异步编程，导致很容易漏掉 http response
回调，使得服务处于不响应状态。增加超时限制会在超时时间达到且没有
响应时强制响应。

issue #574
