### PR TITLE
Revert "调整请求正文的限制为 40mb"

### DIFF
--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -59,9 +59,9 @@ Cloud.use('/__engine/1/ping', function(req, res) {
       next();
     });
 
-    Cloud.use(route, bodyParser.urlencoded({extended: false, limit: '40mb'}));
-    Cloud.use(route, bodyParser.json({limit: '40mb'}));
-    Cloud.use(route, bodyParser.text({limit: '40mb'}));
+    Cloud.use(route, bodyParser.urlencoded({extended: false}));
+    Cloud.use(route, bodyParser.json());
+    Cloud.use(route, bodyParser.text());
 
     // domainWrapper
     Cloud.use(route, function(req, res, next) {


### PR DESCRIPTION
Reverts leancloud/leanengine-node-sdk#50 

最终确定为 20MB。
