### PR TITLE
#77 AV.Cloud.run 本地调用云函数时 request 上缺少 currentUser 等属性

### DIFF
--- a/API.md
+++ b/API.md
@@ -70,9 +70,10 @@ AV.Cloud.run(name: string, data: object, options?: object): Promise
 
 `options` 的属性包括：
 
-* `user: AV.User`：以特定的用户运行云函数（建议在 `remote: false` 时使用）。
-* `sessionToken: string`：以特定的 sessionToken 调用云函数（建议在 `remote: true` 时使用）。
-* `remote: boolean`：通过网络请求来调用云函数，默认 `false`.
+* `user?: AV.User`：以特定的用户运行云函数（建议在 `remote: false` 时使用）。
+* `sessionToken?: string`：以特定的 sessionToken 调用云函数（建议在 `remote: true` 时使用）。
+* `remote?: boolean`：通过网络请求来调用云函数，默认 `false`.
+* `req?`: Express 的 Request 对象，以便被调用的云函数得到 remoteAddress 等属性。
 
 更多有关云函数的内容请参考文档 [云函数开发指南：云函数](https://leancloud.cn/docs/leanengine_cloudfunction_guide-node.html#云函数)。
 
@@ -106,6 +107,8 @@ after 类 Hook 的 `func` 签名：`function(request: Request)`。
 * `success: function()`：允许这个操作，请在 15 秒内调用 `success`, 否则会认为操作被拒绝。
 * `error: function(err: string)`：向客户端返回一个错误并拒绝这个操作。
 
+LeanEngine 中间件会为这些 Hook 函数检查「Hook 签名」，确保调用者的确是 LeanCloud 或本地调试时的命令行工具。
+
 更多有关 Hook 函数的内容请参考文档 [云函数开发指南：Hook 函数](https://leancloud.cn/docs/leanengine_cloudfunction_guide-node.html#Hook_函数)。
 
 ### 登录和认证 Hook
@@ -133,9 +136,13 @@ after 类 Hook 的 `func` 签名：`function(request: Request)`。
 
 * `_messageReceived`
 * `_receiversOffline`
+* `_messageSent`
 * `_conversationStart`
 * `_conversationAdd`
 * `_conversationRemove`
+* `_conversationUpdate`
+
+LeanEngine 中间件会为这些 Hook 函数检查「Hook 签名」，确保调用者的确是 LeanCloud 或本地调试时的命令行工具。
 
 这些 Hook 需要用 `AV.Cloud.define` 来定义，详见文档 [实时通信概览：云引擎 Hook](https://leancloud.cn/docs/realtime_v2.html#云引擎_Hook)
 

--- a/lib/cloud.js
+++ b/lib/cloud.js
@@ -24,7 +24,9 @@ Cloud.define = function(name, options, func) {
 var originalCloudRun = AV.Cloud.run;
 
 Cloud.run = function(name, data, options) {
-  if (options && options.remote) {
+  options = options || {};
+
+  if (options.remote) {
     if (options.user) {
       options.sessionToken = options.sessionToken || options.getSessionToken();
     }
@@ -32,21 +34,28 @@ Cloud.run = function(name, data, options) {
   }
 
   return AV.Promise.as().then(function() {
-    if (options && options.sessionToken) {
+    if (options.sessionToken) {
       return AV.User.become(options.sessionToken);
     }
   }).then(function(user) {
-    user = user || (options && options.user);
+    user = user || options.user;
 
     return new Promise(function(resolve, reject) {
-      Cloud.__code[name]({params: data, user: user}, {
-        success: function(result) {
-          resolve(result);
-        },
-        error: function(err) {
+      var request = utils.prepareRequestObject({
+        user: user,
+        params: data,
+        req: options.req
+      });
+
+      var response = utils.prepareResponseObject(options.req && options.req.res, function(err, result) {
+        if (err) {
           reject(err);
+        } else {
+          resolve(result);
         }
       });
+
+      Cloud.__code[name](request, response);
     });
   }).catch(function(err) {
     console.log('Run function \'' + name + '\' failed with error:', err);

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -115,7 +115,7 @@ function createCloudFunctionRouter(options) {
         '_conversationAdd', '_conversationRemove', '_conversationUpdate'
       ], splited[1])) {
         if (!utils.verifyHookSign(AV.masterKey, splited[1], req.body.__sign)) {
-          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', getRemoveAddress(req));
+          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', utils.getRemoveAddress(req));
           return utils.unauthResp(res);
         }
       }
@@ -141,7 +141,7 @@ function createCloudFunctionRouter(options) {
           onVerified(req, splited[2], userObj);
           sendResponse(null, 'ok');
         } else {
-          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', getRemoveAddress(req));
+          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', utils.getRemoveAddress(req));
           return utils.unauthResp(res);
         }
       } else if (splited[1] === '_User' && splited[2] === 'onLogin') {
@@ -149,7 +149,7 @@ function createCloudFunctionRouter(options) {
           userObj._finishFetch(req.body.object, true);
           onLogin(req, userObj, sendResponse);
         } else {
-          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', getRemoveAddress(req));
+          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', utils.getRemoveAddress(req));
           return utils.unauthResp(res);
         }
       } else if ((splited[1] === 'BigQuery' || splited[1] === 'Insight' ) && splited[2] === 'onComplete') {
@@ -157,7 +157,7 @@ function createCloudFunctionRouter(options) {
           onCompleteBigQueryJob(req.body);
           sendResponse(null, 'ok');
         } else {
-          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', getRemoveAddress(req));
+          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', utils.getRemoveAddress(req));
           return utils.unauthResp(res);
         }
       } else {
@@ -170,7 +170,7 @@ function createCloudFunctionRouter(options) {
         }
 
         if (!verified) {
-          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', getRemoveAddress(req));
+          console.error('LeanEngine: verifyHookSign failed on', (req.originalUrl || req.url), 'from', utils.getRemoveAddress(req));
           return utils.unauthResp(res);
         }
 
@@ -232,13 +232,13 @@ var call = function(funcName, params, user, req, options, cb) {
       params = decodeParams(params);
     }
 
-    var request = prepareRequestObject({
+    var request = utils.prepareRequestObject({
       user: user,
       params: params,
       req: req
     });
 
-    var response = prepareResponseObject(req.res, function(err, result) {
+    var response = utils.prepareResponseObject(req.res, function(err, result) {
       if (!err && options.decodeAVObject) {
         result = encodeResult(result);
       }
@@ -271,7 +271,7 @@ var classHook = function(className, hook, object, user, req, cb) {
   }
 
   try {
-    var request = prepareRequestObject({
+    var request = utils.prepareRequestObject({
       user: user,
       object: obj,
       req: req
@@ -284,7 +284,7 @@ var classHook = function(className, hook, object, user, req, cb) {
       return cb(null, 'ok');
     } else {
       setHookMark('__before', obj);
-      Cloud.__code[hook + className](request, prepareResponseObject(req.res, function(err) {
+      Cloud.__code[hook + className](request, utils.prepareResponseObject(req.res, function(err) {
         if (err) {
           cb(new Error(err));
         } else if ('__before_delete_for_' === hook) {
@@ -319,7 +319,7 @@ var setHookMark = function(hookAction, obj) {
 
 var onVerified = function(req, type, user) {
   try {
-    var request = prepareRequestObject({
+    var request = utils.prepareRequestObject({
       user: user,
       object: user,
       req: req
@@ -333,13 +333,13 @@ var onVerified = function(req, type, user) {
 
 var onLogin = function(req, user, cb) {
   try {
-    var request = prepareRequestObject({
+    var request = utils.prepareRequestObject({
       user: user,
       object: user,
       req: req
     });
 
-    var response = prepareResponseObject(req.res, function(err) {
+    var response = utils.prepareResponseObject(req.res, function(err) {
       if (err) {
         cb(new Error(err));
       } else {
@@ -368,41 +368,6 @@ var hookNameMapping = {
   afterUpdate: '__after_update_for_',
   beforeDelete: '__before_delete_for_',
   afterDelete: '__after_delete_for_'
-};
-
-/* options: req, user, params, object*/
-var prepareRequestObject = function(options) {
-  var req = options.req;
-  var user = options.user;
-
-  var currentUser = user || (req.AV && req.AV.user);
-
-  return {
-    expressReq: req,
-    params: options.params,
-    object: options.object,
-    user: user,
-    meta: {
-      remoteAddress: getRemoveAddress(req)
-    },
-
-    /* User from client */
-    currentUser: currentUser,
-
-    sessionToken: (currentUser && currentUser.getSessionToken()) || req.sessionToken
-  };
-};
-
-var prepareResponseObject = function(res, callback) {
-  return {
-    success: function(result) {
-      callback(null, result);
-    },
-
-    error: function(error) {
-      callback(error);
-    }
-  };
 };
 
 var encodeResult = function(result) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -36,3 +36,41 @@ exports.verifyHookSign = function(masterKey, hookName, sign) {
     return false;
   }
 };
+
+/* options: req, user, params, object*/
+exports.prepareRequestObject = function(options) {
+  var req = options.req;
+  var user = options.user;
+
+  var currentUser = user || (req && req.AV && req.AV.user);
+
+  return {
+    expressReq: req,
+
+    params: options.params,
+    object: options.object,
+    meta: {
+      remoteAddress: req && req.headers && getRemoveAddress(req)
+    },
+
+    user: user,
+    currentUser: currentUser,
+    sessionToken: (currentUser && currentUser.getSessionToken()) || (req && req.sessionToken)
+  };
+};
+
+exports.prepareResponseObject = function(res, callback) {
+  return {
+    success: function(result) {
+      callback(null, result);
+    },
+
+    error: function(error) {
+      callback(error);
+    }
+  };
+};
+
+var getRemoveAddress = exports.getRemoveAddress = function(req) {
+  return req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress
+};


### PR DESCRIPTION
https://github.com/leancloud/leanengine-node-sdk/issues/77

想用 prepareRequestObject 来构造一致的 request 对象，但这取决于用户是否将 express 的 req 传了进来，如果不传进来就需要在 prepareRequestObject 做很多值为空的处理。
