### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+## v1.2.0
+
+* 升级 JavaScript SDK 到 [leancloud-storage 1.3.0](https://github.com/leancloud/javascript-sdk/releases)
+* 支持 Koa，相关文档见 <https://github.com/leancloud/docs/pull/1403>
+
 ## v1.1.0 (2016-06-23)
 
 * **可能存在细微不兼容** 升级 JavaScript SDK 到 [leancloud-storage 1.0.0](https://github.com/leancloud/javascript-sdk/releases)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 npm install leanengine --save
 ```
 
-1.x 版本，推荐新用户使用（[升级到云引擎 Node.js SDK 1.0](https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html)）：
+1.x 版本，推荐新用户使用（旧用户请 [升级到云引擎 Node.js SDK 1.0](https://leancloud.cn/docs/leanengine-node-sdk-upgrade-1.html)）：
 
 ```bash
 npm install leanengine@next --save

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leanengine",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "LeanCloud LeanEngine Node.js SDK.",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "cookies": "0.5.0",
     "debug": "2.0.0",
     "iconv-lite": "^0.4.8",
-    "leancloud-storage": "1.0.0",
+    "leancloud-storage": "1.3.0",
     "on-headers": "1.0.0",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
- 升级 JavaScript SDK 到 [leancloud-storage 1.3.0](https://github.com/leancloud/javascript-sdk/releases)
- 支持 Koa，相关文档见 https://github.com/leancloud/docs/pull/1403

`npm install https://dn-kTzCvF3a.qbox.me/21ebcbba105b1a00.tgz`
