### PR TITLE
✨ Add `internal` option for Cloud.define

### DIFF
--- a/API.md
+++ b/API.md
@@ -53,6 +53,7 @@ AV.Cloud.define(name: string, options: object, func: function)
 `options` 的属性包括：
 
 * `fetchUser: boolean`：是否自动抓取客户端的用户信息，默认为 `true`，若设置为 `false` 则 `request` 上将不会有 user 属性。
+* `internal: boolean`：只允许在云引擎内（使用 `AV.Cloud.run` 且未开启 `remote` 选项）或 masterKey 调用（使用 `AV.Cloud.run` 时传入 `useMasterKey`），不允许客户端直接调用，默认 `false`。
 
 `Request` 上的属性包括：
 

--- a/leanengine.d.ts
+++ b/leanengine.d.ts
@@ -59,6 +59,7 @@ export namespace Insight {
 export namespace Cloud {
   interface DefineOptions {
     fetchUser?: boolean
+    internal?: boolean
   }
 
   interface RunOptions {

--- a/lib/cloud.js
+++ b/lib/cloud.js
@@ -21,6 +21,10 @@ Cloud.define = function(name, options, func) {
     func.fetchUser = false;
   }
 
+  if (options && options.internal) {
+    func.internal = true;
+  }
+
   if (Cloud.functions[name]) {
     throw new Error(`LeanEngine: ${name} already defined`);
   } else {

--- a/lib/leanengine.js
+++ b/lib/leanengine.js
@@ -155,6 +155,10 @@ function callCloudFunction(req, funcName, options) {
     throw new Cloud.Error(`No such cloud function '${funcName}'`, {status: 404, printToLog: true, printFullStack: false});
   }
 
+  if (cloudFunction.internal) {
+    checkInternal(req);
+  }
+
   if (_.contains(_.values(utils.realtimeHookMapping), funcName)) {
     checkHookKey(req);
   }
@@ -337,6 +341,14 @@ function responseError(res, err) {
 function checkHookKey(req) {
   if (req.headers['x-lc-hook-key'] !== AV.hookKey) {
     throw new Cloud.Error(`Hook key check failed, request from ${utils.getRemoteAddress(req)}`, {
+      status: 401, code: 401, printToLog: true, printFullStack: false
+    });
+  }
+}
+
+function checkInternal(req) {
+  if (req.headers['x-lc-hook-key'] !== AV.hookKey && !req.AV.authMasterKey) {
+    throw new Cloud.Error(`Internal cloud function, request from ${utils.getRemoteAddress(req)}`, {
       status: 401, code: 401, printToLog: true, printFullStack: false
     });
   }

--- a/test/authorization-test.js
+++ b/test/authorization-test.js
@@ -118,4 +118,19 @@ describe('authorization', function() {
       .expect({code: 401, error: 'Unauthorized.'}, done);
   });
 
+  it('internal function', done => {
+    request(app)
+      .post('/1/functions/internalFunction')
+      .set('X-LC-Id', appId)
+      .set('X-LC-Key', appKey)
+      .expect(401, done);
+  })
+
+  it('internal function, master key', done => {
+    request(app)
+      .post('/1/functions/internalFunction')
+      .set('X-LC-Id', appId)
+      .set('X-LC-Key', `${masterKey},master`)
+      .expect(200, done);
+  })
 });

--- a/test/fixtures/functions.js
+++ b/test/fixtures/functions.js
@@ -134,6 +134,10 @@ AV.Cloud.define('dontFetchUser', {fetchUser: false}, function(req, res) {
   res.success();
 });
 
+AV.Cloud.define('internalFunction', {internal: true}, () => {
+
+});
+
 AV.Cloud.define('testRun', function(request, response) {
   if (request.params.shouldRemote && process.env.NODE_ENV != 'production') {
     return response.error('Should be run on remote');


### PR DESCRIPTION
PR 中已包含测试和文档，简单来说会在路由层会检查是否有发正确的 hookKey 或 masterKey。

后续任务队列（定时任务）也会发 hookKey，也就是说 internal 的函数也可以用作定时任务。

https://leanticket.cn/tickets/20210