### PR TITLE
test: fix test dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "underscore": "^1.8.3"
   },
   "devDependencies": {
+    "@types/express": "^4.17.2",
     "blanket": "^1.2.3",
     "express": "^4.14.1",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
   },
   "scripts": {
     "test": "npm install --no-save leancloud-storage@3 typescript@2 && npm-run-all test-tsd test-express test-koa1 test-koa2",
-    "test-express": "mocha test test/express",
+    "test-express": "mocha test --timeout 8000 test/express",
     "test-tsd": "tsc --strict leanengine.d.ts",
-    "test-koa1": "npm install --no-save leancloud-storage@3 koa@1 koa-bodyparser@2 && env FRAMEWORK=koa KOA_VER=1 mocha test test/koa",
-    "test-koa2": "npm install --no-save leancloud-storage@3 koa@2 koa-bodyparser@4 && env FRAMEWORK=koa KOA_VER=2 mocha test test/koa"
+    "test-koa1": "npm install --no-save leancloud-storage@3 koa@1 koa-bodyparser@2 && env FRAMEWORK=koa KOA_VER=1 mocha test --timeout 8000 test/koa",
+    "test-koa2": "npm install --no-save leancloud-storage@3 koa@2 koa-bodyparser@4 && env FRAMEWORK=koa KOA_VER=2 mocha test --timeout 8000 test/koa"
   }
 }


### PR DESCRIPTION
1. `tsc --strict` requires `@types/express`
2. increase mocha timeout value (the default 2000 ms is not enough,
  accessing LeanCloud api from travis servers may be slow, failing tests due to timeout)