### PR TITLE
fix: explicitly specify the hookKey

### DIFF
--- a/API.md
+++ b/API.md
@@ -10,6 +10,7 @@ AV.init({
   appId: process.env.LEANCLOUD_APP_ID,
   appKey: process.env.LEANCLOUD_APP_KEY,
   masterKey: process.env.LEANCLOUD_APP_MASTER_KEY
+  hookKey: process.env.LEANCLOUD_APP_HOOK_KEY
 });
 
 app.use(AV.express());

--- a/leanengine.d.ts
+++ b/leanengine.d.ts
@@ -25,7 +25,8 @@ declare namespace Express {
 interface InitializeOptions {
   appId: string,
   appKey: string,
-  masterKey: string
+  masterKey?: string,
+  hookKey?: string,
 }
 
 interface MiddlewareOptions {

--- a/lib/cloud.js
+++ b/lib/cloud.js
@@ -239,6 +239,7 @@ Cloud.start = function() {
       appId: process.env.LEANCLOUD_APP_ID,
       appKey: process.env.LEANCLOUD_APP_KEY,
       masterKey: process.env.LEANCLOUD_APP_MASTER_KEY,
+      hookKey: process.env.LEANCLOUD_APP_HOOK_KEY,
     });
   }
   const app = AV.express();


### PR DESCRIPTION
leancloud-storage 从 4.4.0 起不再自动从环境变量获取 hookKey，这个 key 应该像 masterKey 一样由使用者（leanengine）来指定。

开发者应该感知不到这个改动。