### PR TITLE
Forwarded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # 更新日志
 
+## 3.7.0
+
+- `req.meta.remoteAddress` 优先从 `Forwarded` 头获取客户端 IP，在线上的 Hook 中可以获取到触发 Hook 的客户端 IP。
+- `AV.Cloud.HttpsRedirect` 优先从 `Forwarded` 头判断协议，非 `.leanapp.cn` 域名的预备环境将被正确地重定向。
+
 ## 3.6.0
 
 添加对新的即时通讯 Hook 的支持：

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,9 @@
 'use strict';
 
 var crypto = require('crypto');
+var parseForwarded = require('forwarded-parse');
+var ipaddr = require('ipaddr.js');
+var _ = require('underscore');
 
 exports.hookNameMapping = {
   beforeSave: '__before_save_for_',
@@ -70,9 +73,37 @@ exports.prepareResponseObject = function(res, callback) {
 };
 
 var getRemoteAddress = exports.getRemoteAddress = function(req) {
-  return req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress
+  var forwardedClient = exports.getForwardedClient(req)
+
+  if (forwardedClient) {
+    return forwardedClient.for
+  } else {
+    return req.headers['x-real-ip'] || req.headers['x-forwarded-for'] || req.connection.remoteAddress
+  }
 };
 
 exports.endsWith = function(str, suffix) {
   return str.indexOf(suffix, str.length - suffix.length) !== -1;
 };
+
+exports.getForwardedClient = function getForwardedClient(req) {
+  if (req.headers['forwarded']) {
+    try {
+      const forwards = parseForwarded(req.headers['forwarded']).reverse()
+
+      for (var i = 0; i < forwards.length; i++) {
+        if (!forwards[i].for) {
+          return
+        }
+
+        var range = ipaddr.parse(forwards[i].for).range()
+
+        if (!_.include(['loopback', 'private'], range) || i === forwards.length - 1) {
+          return _.extend(forwards[i], {range: range})
+        }
+      }
+    } catch (err) {
+      console.error('LeanEngine: parse Forwarded header failed', req.headers['forwarded'], err.stack)
+    }
+  }
+}

--- a/middleware/https-redirect.js
+++ b/middleware/https-redirect.js
@@ -1,11 +1,16 @@
 'use strict';
 
 var endsWith = require('../lib/utils').endsWith;
+var getForwardedClient = require('../lib/utils').getForwardedClient;
+var _ = require('underscore');
 
 module.exports = function(AV) {
   return function() {
     return function(req, res, next) {
-      if ((AV.Cloud.__prod || endsWith(req.headers.host, '.leanapp.cn')) && (!req.secure)) {
+      var forwardedClient = getForwardedClient(req)
+
+      if (forwardedClient && forwardedClient.proto === 'http' && !_.include(['loopback', 'private'], forwardedClient.range) ||
+          !forwardedClient && (AV.Cloud.__prod || endsWith(req.headers.host, '.leanapp.cn')) && (!req.secure)) {
         const url = `https://${req.headers.host}${req.originalUrl || req.url}`;
 
         res.statusCode = 302;

--- a/package-lock.json
+++ b/package-lock.json
@@ -757,6 +757,11 @@
       "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
       "dev": true
     },
+    "forwarded-parse": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/forwarded-parse/-/forwarded-parse-2.1.0.tgz",
+      "integrity": "sha512-as9a7Xelt0CvdUy7/qxrY73dZq2vMx49F556fwjjFrUyzq5uHHfeLgD2cCq/6P4ZvusGZzjD6aL2NdgGdS5Cew=="
+    },
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -884,8 +889,7 @@
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
     "is-arrayish": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "leanengine",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -120,36 +120,44 @@
       }
     },
     "@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.6.tgz",
+      "integrity": "sha512-n/mr9tZI83kd4azlPG5y997C/M4DNABK9yErhFM6hKdym4kkmd9j0vtsJyjFIwfRBxtrxZtAfGZCNRIBMFLK5w==",
       "dev": true,
       "requires": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "*",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.2",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.2.tgz",
-      "integrity": "sha512-El9yMpctM6tORDAiBwZVLMcxoTMcqqRO9dVyYcn7ycLWbvR8klrDn8CAOwRfZujZtWD7yS/mshTdz43jMOejbg==",
+      "version": "4.17.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.7.tgz",
+      "integrity": "sha512-EMgTj/DF9qpgLXyc+Btimg+XoH7A2liE8uKul8qSmMTHCeNYzydDKFdsJskDvw42UsesCnhO63dO0Grbj8J4Dw==",
       "dev": true,
       "requires": {
         "@types/node": "*",
+        "@types/qs": "*",
         "@types/range-parser": "*"
       }
     },
     "@types/mime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
-      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.2.tgz",
+      "integrity": "sha512-4kPlzbljFcsttWEq6aBW0OZe6BDajAmyvr2xknBG92tejQnvdGtT9+kXSZ580DqpxY9qG2xeQVF9Dq0ymUTo5Q==",
       "dev": true
     },
     "@types/node": {
-      "version": "13.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ==",
+      "version": "14.0.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.13.tgz",
+      "integrity": "sha512-rouEWBImiRaSJsVA+ITTFM6ZxibuAlTuNOCyxVbwreu6k6+ujs7DfnU9o+PShFhET78pMBl3eH+AGSI5eOTkPA==",
+      "dev": true
+    },
+    "@types/qs": {
+      "version": "6.9.3",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.3.tgz",
+      "integrity": "sha512-7s9EQWupR1fTc2pSMtXRQ9w9gLOcrJn+h7HOXw4evxyvVqMi4f+q7d2tnFe3ng3SNHjtK+0EzGMGFUQX4/AQRA==",
       "dev": true
     },
     "@types/range-parser": {
@@ -159,9 +167,9 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
-      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.4.tgz",
+      "integrity": "sha512-jTDt0o/YbpNwZbQmE/+2e+lfjJEJJR0I3OFaKQKPWkASkCoW3i6fsUnqudSMcNAfbtmADGu8f4MV4q+GqULmug==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -1933,15 +1941,15 @@
       }
     },
     "typescript": {
-      "version": "3.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.5.tgz",
+      "integrity": "sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==",
       "dev": true
     },
     "underscore": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "ipaddr.js": "^1.9.1",
     "leancloud-cors-headers": "^0.1.0",
     "on-headers": "^1.0.1",
-    "underscore": "^1.8.3"
+    "underscore": "^1.10.2"
   },
   "devDependencies": {
-    "@types/express": "^4.17.2",
+    "@types/express": "^4.17.6",
     "blanket": "^1.2.3",
     "express": "^4.14.1",
     "leancloud-storage": "^3.15.0",
@@ -27,7 +27,7 @@
     "npm-run-all": "^4.1.2",
     "should": "^11.2.0",
     "supertest": "^3.0.0",
-    "typescript": "^3.8.3"
+    "typescript": "^3.9.5"
   },
   "peerDependency": {
     "leancloud-storage": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "connect-timeout": "^1.8.0",
     "cookies": "^0.6.2",
     "debug": "^2.6.0",
+    "forwarded-parse": "^2.1.0",
+    "ipaddr.js": "^1.9.1",
     "leancloud-cors-headers": "^0.1.0",
     "on-headers": "^1.0.1",
     "underscore": "^1.8.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leanengine",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "LeanCloud LeanEngine Node.js SDK.",
   "repository": {
     "type": "git",

--- a/test/fixtures/functions.js
+++ b/test/fixtures/functions.js
@@ -231,6 +231,10 @@ AV.Cloud.define('testTimeout', function(req, res) {
   }, req.params.delay);
 });
 
+AV.Cloud.define('remoteAddress', function(request) {
+  return request.meta.remoteAddress
+})
+
 AV.Cloud.onIMMessageReceived(function(request, response) {
   response.success('ok');
 });

--- a/test/function-test.js
+++ b/test/function-test.js
@@ -452,6 +452,31 @@ describe('functions', function() {
       });
   });
 
+  it('remoteAddress', function(done) {
+    request(app)
+      .post('/1.1/functions/remoteAddress')
+      .set('X-AVOSCloud-Application-Id', appId)
+      .set('X-AVOSCloud-Application-Key', appKey)
+      .set('Forwarded', 'for=1.2.3.4; proto=https, for=10.0.0.1')
+      .expect(200, (err, res) => {
+        res.body.result.should.equal('1.2.3.4')
+        done(err)
+      });
+  })
+
+  it('remoteAddress invalid Forwarded header', function(done) {
+    request(app)
+      .post('/1.1/functions/remoteAddress')
+      .set('X-AVOSCloud-Application-Id', appId)
+      .set('X-AVOSCloud-Application-Key', appKey)
+      .set('Forwarded', 'for=1.2.3.456; proto=https, for=10.0.0.1')
+      .set('X-Real-IP', '5.6.7.8')
+      .expect(200, (err, res) => {
+        res.body.result.should.equal('5.6.7.8')
+        done(err)
+      });
+  })
+
   it('_metadatas', function(done) {
     request(app)
       .get('/1/functions/_ops/metadatas')


### PR DESCRIPTION
这个 PR 会替代 https://github.com/leancloud/leanengine-node-sdk/pull/149/files

相关的 Issue：

- https://github.com/leancloud/uluru-platform/issues/6100
- https://github.com/leancloud/uluru-nginx/pull/307
- https://github.com/leancloud/rfcs/issues/1061

对于 Forwarded 的信任：

从右往左逐个判断，如果客户端地址是内网或本地环回的话，认为它是一个可信任的内网代理，继续向左找，直到第一个外网地址或最后一个地址。

修改后的行为：

- req.meta.remoteAddress 优先从 Forwarded 获取客户端 IP；如果没有 Forwarded 行为不变
- AV.Cloud.HttpsRedirect 优先从 Forwarded 获取协议，如果请求来自外网且是 http 就重定向；如果没有 Forwarded 行为不变

HttpsRedirect 需要修改是因为之前我们为了避免内网请求（Hook）被重定向，内部约定内网请求都发 X-Forwarded-Proto: https，但其实这是不符合实际情况，会造成一些混乱，现在 Forwarded 可以彻底解决这个问题。

尚存的一些问题：

- 还未向网站托管的代码提供从 Forwarded 读取客户端信息的工具函数
- 还需要把这个机制更新到 https://github.com/leancloud/rfcs/wiki/LeanEngine-Runtime-SDK-Specification 并要求其他 SDK 修改
- 后续是否要去除对 X-Real-IP、X-Forwarded-For、X-Forwarded-Proto 的支持，虽然 Forwarded 已纳入标准且扩展性较好，但配套并不完善，如 Nginx 和 express 都没有自带对 Forwarded 支持。