### PR TITLE
fix: type defination of CloudFunctionRequest.params

### DIFF
--- a/leanengine.d.ts
+++ b/leanengine.d.ts
@@ -111,7 +111,7 @@ export namespace Cloud {
 
   interface CloudFunctionRequest {
     meta: CloudFunctionRequestMeta,
-    params: Object,
+    params: Record<string, any>,
     currentUser?: User,
     sessionToken?: string
   }


### PR DESCRIPTION
感觉应该是 `Record<string, any>` 而不是 `AV.Object` ，但我不是很确定。